### PR TITLE
Update files to be compatible with scripts in pair-warp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ exts/omni.warp/config/extension.gen.toml
 /external/llvm-project
 /build
 /dist
+pair-warp
+warp/bin
+outputs/

--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ Pre-built binary packages for Windows and Linux are also available on the [Relea
 
     pip install .
 
+This is the PAIR lab's custom fork of Warp, which is compatible with our set of custom utils and scripts. These tools can be found in [this repository](https://github.com/pairlab/pair-warp).
+
+To use PAIR's custom Warp tools, clone the repository into the root directory of this repository:
+
+    git clone https://github.com/pairlab/pair-warp.git
+
+To run an example script, run the following command from the root directory of this repository (run_task.py, for example):
+
+    python -m pair-warp.scripts.run_task
+
 ## Getting Started
 
 An example first program that computes the lengths of random 3D vectors is given below:

--- a/examples/benchmark_api.py
+++ b/examples/benchmark_api.py
@@ -23,12 +23,14 @@ def dec_kernel(a: wp.array(dtype=float)):
 
 
 def test_allocs(n, device, do_sync=False):
+
     arrs = [None] * n
 
     with wp.ScopedTimer("allocs"):
+
         for i in range(n):
             arrs[i] = wp.zeros(1, device=device)
-
+    
         if do_sync:
             wp.synchronize()
 
@@ -36,12 +38,14 @@ def test_allocs(n, device, do_sync=False):
 
 
 def test_allocs_v2(n, device, do_sync=False):
+
     arrs = [None] * n
 
     with wp.ScopedTimer("allocs_v2"), wp.ScopedDevice(device):
+
         for i in range(n):
             arrs[i] = wp.zeros(1)
-
+    
         if do_sync:
             wp.synchronize()
 
@@ -49,10 +53,12 @@ def test_allocs_v2(n, device, do_sync=False):
 
 
 def test_launches(n, device, do_sync=False):
+
     arr = wp.zeros(1, dtype=wp.float32, device=device)
     wp.synchronize()
-
+    
     with wp.ScopedTimer("launches"):
+
         for _ in range(n):
             wp.launch(inc_kernel, dim=arr.size, inputs=[arr], device=device)
             wp.launch(dec_kernel, dim=arr.size, inputs=[arr], device=device)
@@ -62,10 +68,12 @@ def test_launches(n, device, do_sync=False):
 
 
 def test_launches_v2(n, device, do_sync=False):
+
     arr = wp.zeros(1, dtype=wp.float32, device=device)
     wp.synchronize()
 
     with wp.ScopedTimer("launches_v2"), wp.ScopedDevice(device):
+
         for _ in range(n):
             wp.launch(inc_kernel, dim=arr.size, inputs=[arr])
             wp.launch(dec_kernel, dim=arr.size, inputs=[arr])
@@ -75,6 +83,7 @@ def test_launches_v2(n, device, do_sync=False):
 
 
 def test_copies(n, do_sync=False):
+    
     a = wp.zeros(1, dtype=wp.float32, device="cpu")
     b = wp.zeros(1, dtype=wp.float32, device="cuda")
     c = wp.zeros(1, dtype=wp.float32, device="cuda")
@@ -82,6 +91,7 @@ def test_copies(n, do_sync=False):
     wp.synchronize()
 
     with wp.ScopedTimer("copies"):
+
         for _ in range(n):
             wp.copy(b, a)
             wp.copy(c, b)
@@ -92,6 +102,7 @@ def test_copies(n, do_sync=False):
 
 
 def test_graphs(n, device, do_sync=False):
+
     arr = wp.zeros(1, dtype=wp.float32, device=device)
     wp.synchronize()
 
@@ -102,6 +113,7 @@ def test_graphs(n, device, do_sync=False):
     wp.synchronize()
 
     with wp.ScopedTimer("graphs"):
+
         for _ in range(n):
             wp.capture_launch(graph)
 
@@ -147,7 +159,7 @@ wp.synchronize()
 gc.collect()
 
 
-# ========= profiling ==========#
+#========= profiling ==========#
 
 # import cProfile
 # cProfile.run('test_allocs(n, device)')

--- a/examples/env/env_ant.py
+++ b/examples/env/env_ant.py
@@ -30,12 +30,14 @@ class AntEnvironment(Environment):
     usd_render_settings = dict(scaling=100.0)
 
     sim_substeps_euler = 32
-    sim_substeps_xpbd = 3
+    sim_substeps_xpbd = 5
 
     joint_attach_ke: float = 100000.0
     joint_attach_kd: float = 10.0
 
     use_graph_capture = True
+    use_tiled_rendering = False
+    show_joints = False
 
     def create_articulation(self, builder):
         wp.sim.parse_mjcf(

--- a/examples/env/env_cartpole.py
+++ b/examples/env/env_cartpole.py
@@ -32,6 +32,7 @@ class CartpoleEnvironment(Environment):
     sim_substeps_xpbd = 5
 
     activate_ground_plane = False
+    show_joints = True
 
     show_joints = True
 
@@ -41,6 +42,7 @@ class CartpoleEnvironment(Environment):
             builder,
             xform=wp.transform((0.0, 0.0, 0.0), wp.quat_from_axis_angle((1.0, 0.0, 0.0), -math.pi * 0.5)),
             floating=False,
+            density=1000.0,
             armature=0.1,
             stiffness=0.0,
             damping=0.0,

--- a/examples/env/env_humanoid.py
+++ b/examples/env/env_humanoid.py
@@ -39,6 +39,9 @@ class HumanoidEnvironment(Environment):
         rigid_contact_con_weighting=True,
     )
 
+    use_tiled_rendering = False
+    show_joints = False
+
     def create_articulation(self, builder):
         wp.sim.parse_mjcf(
             os.path.join(os.path.dirname(__file__), "../assets/nv_humanoid.xml"),

--- a/examples/env/environment.py
+++ b/examples/env/environment.py
@@ -35,7 +35,7 @@ class IntegratorType(Enum):
         return self.value
 
 
-def compute_env_offsets(num_envs, env_offset=(5.0, 0.0, 5.0), up_axis="Y"):
+def compute_env_offsets(num_envs, env_offset=(5.0, 0.0, 5.0), up_axis="y"):
     # compute positional offsets per environment
     env_offset = np.array(env_offset)
     nonzeros = np.nonzero(env_offset)[0]
@@ -70,7 +70,7 @@ def compute_env_offsets(num_envs, env_offset=(5.0, 0.0, 5.0), up_axis="Y"):
     min_offsets = np.min(env_offsets, axis=0)
     correction = min_offsets + (np.max(env_offsets, axis=0) - min_offsets) / 2.0
     if isinstance(up_axis, str):
-        up_axis = "XYZ".index(up_axis.upper())
+        up_axis = "xyz".index(up_axis.lower())
     correction[up_axis] = 0.0  # ensure the envs are not shifted below the ground plane
     env_offsets -= correction
     return env_offsets
@@ -114,13 +114,16 @@ class Environment:
 
     integrator_type: IntegratorType = IntegratorType.XPBD
 
-    up_axis: str = "Y"
+    up_axis: str = "y"
     gravity: float = -9.81
     env_offset: Tuple[float, float, float] = (1.0, 0.0, 1.0)
 
     # stiffness and damping for joint attachment dynamics used by Euler
     joint_attach_ke: float = 32000.0
     joint_attach_kd: float = 50.0
+
+    # maximum number of rigid contact points to generate per mesh
+    rigid_mesh_contact_max: int = 0  # (0 = unlimited)
 
     # distance threshold at which contacts are generated
     rigid_contact_margin: float = 0.05
@@ -168,8 +171,10 @@ class Environment:
     def init(self):
         if self.integrator_type == IntegratorType.EULER:
             self.sim_substeps = self.sim_substeps_euler
+            self.integrator = wp.sim.SemiImplicitIntegrator(**self.euler_settings)
         elif self.integrator_type == IntegratorType.XPBD:
             self.sim_substeps = self.sim_substeps_xpbd
+            self.integrator = wp.sim.XPBDIntegrator(**self.xpbd_settings)
 
         self.episode_frames = int(self.episode_duration / self.frame_dt)
         self.sim_dt = self.frame_dt / self.sim_substeps
@@ -180,6 +185,7 @@ class Environment:
             self.env_offset = (0.0, 0.0, 0.0)
 
         builder = wp.sim.ModelBuilder()
+        builder.rigid_mesh_contact_max = self.rigid_mesh_contact_max
         builder.rigid_contact_margin = self.rigid_contact_margin
         try:
             articulation_builder = wp.sim.ModelBuilder()
@@ -196,7 +202,7 @@ class Environment:
             self.setup(builder)
             self.bodies_per_env = len(builder.body_q)
 
-        self.model = builder.finalize()
+        self.model = builder.finalize(integrator=self.integrator)
         self.device = self.model.device
         if not self.device.is_cuda:
             self.use_graph_capture = False
@@ -208,11 +214,6 @@ class Environment:
         # set up current and next state to be used by the integrator
         self.state_0 = None
         self.state_1 = None
-
-        if self.integrator_type == IntegratorType.EULER:
-            self.integrator = wp.sim.SemiImplicitIntegrator(**self.euler_settings)
-        elif self.integrator_type == IntegratorType.XPBD:
-            self.integrator = wp.sim.XPBDIntegrator(**self.xpbd_settings)
 
         self.renderer = None
         if self.profile:

--- a/examples/example_dem.py
+++ b/examples/example_dem.py
@@ -134,8 +134,9 @@ class Example:
         self.k_mu = 100000.0  # for cohesive materials
 
         self.inv_mass = 64.0
-
-        self.renderer = wp.render.UsdRenderer(stage)
+       
+        # self.renderer = wp.render.UsdRenderer(stage)
+        self.renderer = wp.render.NanoRenderer(stage, vsync=False)
         self.renderer.render_ground()
 
         self.grid = wp.HashGrid(128, 128, 128)

--- a/examples/example_mesh.py
+++ b/examples/example_mesh.py
@@ -9,7 +9,7 @@
 # Example Mesh
 #
 # Shows how to implement a PBD particle simulation with collision against
-# a deforming triangle mesh. The mesh collision uses wp.mesh_query_point_sign_normal()
+# a deforming triangle mesh. The mesh collision uses wp.mesh_query_point()
 # to compute the closest point, and wp.Mesh.refit() to update the mesh
 # object after deformation.
 #
@@ -65,7 +65,7 @@ def simulate(
 
     max_dist = 1.5
 
-    if wp.mesh_query_point_sign_normal(mesh, xpred, max_dist, sign, face_index, face_u, face_v):
+    if wp.mesh_query_point(mesh, xpred, max_dist, sign, face_index, face_u, face_v):
         p = wp.mesh_eval_position(mesh, face_index, face_u, face_v)
 
         delta = xpred - p

--- a/examples/example_nvdb.py
+++ b/examples/example_nvdb.py
@@ -62,13 +62,10 @@ def simulate(
     xpred = x + v * dt
     xpred_local = wp.volume_world_to_index(volume, xpred)
 
-    #d = wp.volume_sample_f(volume, xpred_local, wp.Volume.LINEAR)
-    n = wp.vec3()
-    d = wp.volume_sample_grad_f(volume, xpred_local, wp.Volume.LINEAR, n)
+    d = wp.volume_sample_f(volume, xpred_local, wp.Volume.LINEAR)
 
     if d < margin:
-        #n = volume_grad(volume, xpred)
-        n = wp.normalize(n)
+        n = volume_grad(volume, xpred)
         err = d - margin
 
         # mesh collision

--- a/examples/example_render_opengl.py
+++ b/examples/example_render_opengl.py
@@ -41,11 +41,11 @@ else:
 if num_tiles > 1:
     # set up instances to hide one of the capsules in each tile
     for i in range(num_tiles):
-        instances = [j for j in np.arange(13) if j != i + 2]
+        instances = [j for j in np.arange(13) if j != i+2]
         instance_ids.append(instances)
         if custom_tile_arrangement:
-            angle = np.pi * 2.0 / num_tiles * i
-            positions.append((int(np.cos(angle) * 150 + 250), int(np.sin(angle) * 150 + 250)))
+            angle = np.pi*2.0 / num_tiles * i
+            positions.append((int(np.cos(angle)*150 + 250), int(np.sin(angle)*150 + 250)))
             sizes.append((150, 150))
     renderer.setup_tiled_rendering(instance_ids, tile_positions=positions, tile_sizes=sizes)
 
@@ -53,7 +53,6 @@ renderer.render_ground()
 
 if show_plot:
     import matplotlib.pyplot as plt
-
     if split_up_tiles:
         pixels = wp.zeros((num_tiles, renderer.tile_height, renderer.tile_width, 3), dtype=wp.float32)
         ncols = int(np.ceil(np.sqrt(num_tiles)))
@@ -68,7 +67,7 @@ if show_plot:
             squeeze=False,
             sharex=True,
             sharey=True,
-            num=1,
+            num=1
         )
         tile_temp = np.zeros((renderer.tile_height, renderer.tile_width, 3), dtype=np.float32)
         for dim in range(ncols * nrows):
@@ -89,23 +88,9 @@ while renderer.is_running():
     time = renderer.clock_time
     renderer.begin_frame(time)
     for i in range(10):
-        renderer.render_capsule(
-            f"capsule_{i}", [i - 5.0, np.sin(time + i * 0.2), -3.0], [0.0, 0.0, 0.0, 1.0], radius=0.5, half_height=0.8
-        )
-    renderer.render_cylinder(
-        "cylinder",
-        [3.2, 1.0, np.sin(time + 0.5)],
-        np.array(wp.quat_from_axis_angle((1.0, 0.0, 0.0), np.sin(time + 0.5))),
-        radius=0.5,
-        half_height=0.8,
-    )
-    renderer.render_cone(
-        "cone",
-        [-1.2, 1.0, 0.0],
-        np.array(wp.quat_from_axis_angle((0.707, 0.707, 0.0), time)),
-        radius=0.5,
-        half_height=0.8,
-    )
+        renderer.render_capsule(f"capsule_{i}", [i-5.0, np.sin(time+i*0.2), -3.0], [0.0, 0.0, 0.0, 1.0], radius=0.5, half_height=0.8)
+    renderer.render_cylinder("cylinder", [3.2, 1.0, np.sin(time+0.5)], np.array(wp.quat_from_axis_angle((1.0, 0.0, 0.0), np.sin(time+0.5))), radius=0.5, half_height=0.8)
+    renderer.render_cone("cone", [-1.2, 1.0, 0.0], np.array(wp.quat_from_axis_angle((0.707, 0.707, 0.0), time)), radius=0.5, half_height=0.8)
     renderer.end_frame()
 
     if show_plot and plt.fignum_exists(1):

--- a/examples/example_sim_cartpole.py
+++ b/examples/example_sim_cartpole.py
@@ -52,7 +52,7 @@ class Example:
             articulation_builder,
             xform=wp.transform(np.zeros(3), wp.quat_from_axis_angle((1.0, 0.0, 0.0), -math.pi * 0.5)),
             floating=False,
-            density=100,
+            density=0,
             armature=0.1,
             stiffness=0.0,
             damping=0.0,
@@ -84,7 +84,7 @@ class Example:
         self.model.joint_attach_ke = 1600.0
         self.model.joint_attach_kd = 20.0
 
-        self.integrator = wp.sim.SemiImplicitIntegrator()
+        self.integrator = self.model.integrator = wp.sim.SemiImplicitIntegrator()
 
         # -----------------------
         # set up Usd renderer
@@ -133,7 +133,7 @@ class Example:
                 if self.enable_rendering:
                     with wp.ScopedTimer("render", active=True):
                         self.render()
-                    self.renderer.save()
+                    # self.renderer.save()
 
             wp.synchronize()
 

--- a/examples/example_sim_cloth.py
+++ b/examples/example_sim_cloth.py
@@ -13,10 +13,8 @@
 #
 ###########################################################################
 
-import argparse
 import os
 import math
-from enum import Enum
 
 import numpy as np
 
@@ -29,29 +27,9 @@ from pxr import Usd, UsdGeom
 
 wp.init()
 
-class IntegratorType(Enum):
-    EULER = "euler"
-    XPBD = "xpbd"
-
-    def __str__(self):
-        return self.value
 
 class Example:
     def __init__(self, stage):
-
-        self.parser = argparse.ArgumentParser()
-        self.parser.add_argument(
-            "--integrator",
-            help="Type of integrator",
-            type=IntegratorType,
-            choices=list(IntegratorType),
-            default=IntegratorType.EULER,
-        )
-
-        args = self.parser.parse_args()
-
-        self.integrator_type = args.integrator
-
         self.sim_width = 64
         self.sim_height = 32
 
@@ -62,41 +40,23 @@ class Example:
         self.sim_dt = (1.0 / self.sim_fps) / self.sim_substeps
         self.sim_time = 0.0
         self.sim_use_graph = wp.get_device().is_cuda
-        self.simulate_timer = wp.ScopedTimer("simulate", dict={})
 
         builder = wp.sim.ModelBuilder()
 
-        if self.integrator_type == IntegratorType.EULER:
-            builder.add_cloth_grid(
-                pos=(0.0, 4.0, 0.0),
-                rot=wp.quat_from_axis_angle((1.0, 0.0, 0.0), math.pi * 0.5),
-                vel=(0.0, 0.0, 0.0),
-                dim_x=self.sim_width,
-                dim_y=self.sim_height,
-                cell_x=0.1,
-                cell_y=0.1,
-                mass=0.1,
-                fix_left=True,
-                tri_ke=1.0e3,
-                tri_ka=1.0e3,
-                tri_kd=1.0e1,
-            )
-        else:
-            builder.add_cloth_grid(
-                pos=(0.0, 4.0, 0.0),
-                rot=wp.quat_from_axis_angle((1.0, 0.0, 0.0), math.pi * 0.5),
-                vel=(0.0, 0.0, 0.0),
-                dim_x=self.sim_width,
-                dim_y=self.sim_height,
-                cell_x=0.1,
-                cell_y=0.1,
-                mass=0.1,
-                fix_left=True,
-                edge_ke=1.0e2,
-                add_springs=True,
-                spring_ke=1.0e3,
-                spring_kd=0.0,
-            )
+        builder.add_cloth_grid(
+            pos=(0.0, 4.0, 0.0),
+            rot=wp.quat_from_axis_angle((1.0, 0.0, 0.0), math.pi * 0.5),
+            vel=(0.0, 0.0, 0.0),
+            dim_x=self.sim_width,
+            dim_y=self.sim_height,
+            cell_x=0.1,
+            cell_y=0.1,
+            mass=0.1,
+            fix_left=True,
+            tri_ke=1.0e3,
+            tri_ka=1.0e3,
+            tri_kd=1.0e1,
+        )
 
         usd_stage = Usd.Stage.Open(os.path.join(os.path.dirname(__file__), "assets/bunny.usd"))
         usd_geom = UsdGeom.Mesh(usd_stage.GetPrimAtPath("/bunny/bunny"))
@@ -119,13 +79,9 @@ class Example:
 
         self.model = builder.finalize()
         self.model.ground = True
-        self.model.soft_contact_ke = 1.0e4
         self.model.soft_contact_kd = 1.0e2
 
-        if self.integrator_type == IntegratorType.EULER:
-            self.integrator = wp.sim.SemiImplicitIntegrator()
-        else:
-            self.integrator = wp.sim.XPBDIntegrator(iterations=1)
+        self.integrator = wp.sim.SemiImplicitIntegrator()
 
         self.state_0 = self.model.state()
         self.state_1 = self.model.state()
@@ -149,7 +105,7 @@ class Example:
             self.graph = wp.capture_end()
 
     def update(self):
-        with self.simulate_timer:
+        with wp.ScopedTimer("simulate", active=True):
             if self.sim_use_graph:
                 wp.capture_launch(self.graph)
             else:
@@ -182,8 +138,5 @@ if __name__ == "__main__":
     for i in range(example.sim_frames):
         example.update()
         example.render()
-
-    frame_times = example.simulate_timer.dict["simulate"]
-    print("\nAverage frame sim time: {:.2f} ms".format(sum(frame_times) / len(frame_times)))
 
     example.renderer.save()

--- a/examples/example_sim_grad_cloth.py
+++ b/examples/example_sim_grad_cloth.py
@@ -48,7 +48,6 @@ class Cloth:
 
     def __init__(self, render=True, profile=False, adapter=None):
         builder = wp.sim.ModelBuilder()
-        builder.default_particle_radius = 0.01
 
         dim_x = 16
         dim_y = 16
@@ -74,7 +73,9 @@ class Cloth:
 
         self.model = builder.finalize(self.device)
         self.model.ground = False
-
+        # soft contact distance determines the size of the rendered particles
+        self.model.soft_contact_distance = 0.01
+        
         self.integrator = wp.sim.SemiImplicitIntegrator()
 
         self.target = (8.0, 0.0, 0.0)
@@ -86,10 +87,11 @@ class Cloth:
         for i in range(self.sim_steps + 1):
             self.states.append(self.model.state(requires_grad=True))
 
-        if self.render:
+        if (self.render):
             self.stage = wp.sim.render.SimRendererOpenGL(
-                self.model, os.path.join(os.path.dirname(__file__), "outputs/example_sim_grad_cloth.usd"), scaling=4.0
-            )
+                self.model,
+                os.path.join(os.path.dirname(__file__), "outputs/example_sim_grad_cloth.usd"),
+                scaling=4.0)
 
     @wp.kernel
     def com_kernel(positions: wp.array(dtype=wp.vec3), n: int, com: wp.array(dtype=wp.vec3)):
@@ -155,7 +157,8 @@ class Cloth:
 
             self.render_time += self.frame_dt
 
-    def train(self, mode="gd"):
+    def train(self, mode='gd'):
+
         tape = wp.Tape()
 
         for i in range(self.train_iters):
@@ -205,7 +208,7 @@ class Cloth:
                 wp.launch(self.step_kernel, dim=len(x), inputs=[x, x.grad, self.train_rate], device=self.device)
 
             tape.zero()
-
+        
         self.stage.save()
 
 

--- a/examples/example_sim_granular.py
+++ b/examples/example_sim_granular.py
@@ -35,7 +35,6 @@ class Example:
         self.radius = 0.1
 
         builder = wp.sim.ModelBuilder()
-        builder.default_particle_radius = self.radius
 
         builder.add_particle_grid(
             dim_x=16,
@@ -52,6 +51,7 @@ class Example:
         )
 
         self.model = builder.finalize()
+        self.model.particle_radius = self.radius
         self.model.particle_kf = 25.0
 
         self.model.soft_contact_kd = 100.0

--- a/examples/example_sim_particle_chain.py
+++ b/examples/example_sim_particle_chain.py
@@ -14,7 +14,6 @@
 ###########################################################################
 
 import os
-import math
 
 import warp as wp
 import warp.sim
@@ -42,9 +41,7 @@ class Example:
 
         # chain
         for i in range(1, 10):
-            radius = math.sqrt(i) * 0.2
-            mass = math.pi * radius * radius * radius
-            builder.add_particle((i, 1.0, 0.0), (0.0, 0.0, 0.0), mass, radius=radius)
+            builder.add_particle((i, 1.0, 0.0), (0.0, 0.0, 0.0), 1.0)
             builder.add_spring(i - 1, i, 1.0e6, 0.0, 0)
 
         self.model = builder.finalize()

--- a/examples/example_sim_quadruped.py
+++ b/examples/example_sim_quadruped.py
@@ -130,7 +130,6 @@ class Example:
                 if self.enable_rendering:
                     with wp.ScopedTimer("render", active=True):
                         self.render()
-                    self.renderer.save()
 
             wp.synchronize()
 
@@ -138,6 +137,8 @@ class Example:
         avg_steps_second = 1000.0 * float(self.num_envs) / avg_time
 
         print(f"envs: {self.num_envs} steps/second {avg_steps_second} avg_time {avg_time}")
+        
+        self.renderer.save()
 
         return 1000.0 * float(self.num_envs) / avg_time
 

--- a/examples/example_sim_rigid_fem.py
+++ b/examples/example_sim_rigid_fem.py
@@ -37,7 +37,6 @@ class Example:
         self.sim_relaxation = 1.0
 
         builder = wp.sim.ModelBuilder()
-        builder.default_particle_radius = 0.01
 
         builder.add_soft_grid(
             pos=(0.0, 0.0, 0.0),
@@ -60,6 +59,7 @@ class Example:
 
         self.model = builder.finalize()
         self.model.ground = True
+        self.model.soft_contact_distance = 0.01
         self.model.soft_contact_ke = 1.0e3
         self.model.soft_contact_kd = 0.0
         self.model.soft_contact_kf = 1.0e3

--- a/examples/example_sim_trajopt.py
+++ b/examples/example_sim_trajopt.py
@@ -95,6 +95,8 @@ class Environment:
 
         assert len(self.ref_traj) == self.episode_frames * self.state_dim
 
+        solve_iterations = 1
+        # self.integrator = wp.sim.XPBDIntegrator(solve_iterations)
         self.integrator = wp.sim.SemiImplicitIntegrator()
 
     def simulate(self, state: wp.sim.State, action: wp.array, action_index: int, requires_grad=False) -> wp.sim.State:

--- a/warp/__init__.py
+++ b/warp/__init__.py
@@ -10,9 +10,8 @@
 
 from warp.types import array, array1d, array2d, array3d, array4d, constant
 from warp.types import indexedarray, indexedarray1d, indexedarray2d, indexedarray3d, indexedarray4d
-from warp.fabric import fabricarray, fabricarrayarray, indexedfabricarray, indexedfabricarrayarray
 
-from warp.types import bool, int8, uint8, int16, uint16, int32, uint32, int64, uint64, float16, float32, float64
+from warp.types import int8, uint8, int16, uint16, int32, uint32, int64, uint64, float16, float32, float64
 from warp.types import vec2, vec2b, vec2ub, vec2s, vec2us, vec2i, vec2ui, vec2l, vec2ul, vec2h, vec2f, vec2d
 from warp.types import vec3, vec3b, vec3ub, vec3s, vec3us, vec3i, vec3ui, vec3l, vec3ul, vec3h, vec3f, vec3d
 from warp.types import vec4, vec4b, vec4ub, vec4s, vec4us, vec4i, vec4ui, vec4l, vec4ul, vec4h, vec4f, vec4d
@@ -79,7 +78,3 @@ from warp.dlpack import from_dlpack, to_dlpack
 from warp.constants import *
 
 from . import builtins
-
-import warp.config
-
-__version__ = warp.config.version

--- a/warp/builtins.py
+++ b/warp/builtins.py
@@ -5,12 +5,15 @@
 # distribution of this software and related documentation without an express
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 
-import builtins
-from typing import Any, Callable, Dict, List, Tuple
+from .context import add_builtin
 
 from warp.types import *
 
-from .context import add_builtin
+from typing import Tuple
+from typing import List
+from typing import Dict
+from typing import Any
+from typing import Callable
 
 
 def sametype_value_func(default):
@@ -589,9 +592,6 @@ for t in scalar_types_all:
         add_builtin(
             t.__name__, input_types={"u": u}, value_type=t, doc="", hidden=True, group="Scalar Math", export=False
         )
-
-for u in [bool, builtins.bool]:
-    add_builtin(bool.__name__, input_types={"u": u}, value_type=bool, doc="", hidden=True, export=False, namespace="")
 
 
 def vector_constructor_func(args, kwds, templates):
@@ -1437,7 +1437,7 @@ add_builtin(
 add_builtin(
     "bvh_query_next",
     input_types={"query": bvh_query_t, "index": int},
-    value_type=builtins.bool,
+    value_type=bool,
     group="Geometry",
     doc="""Move to the next bound returned by the query. The index of the current bound is stored in ``index``, returns ``False``
    if there are no more overlapping bound.""",
@@ -1454,7 +1454,7 @@ add_builtin(
         "bary_u": float,
         "bary_v": float,
     },
-    value_type=builtins.bool,
+    value_type=bool,
     group="Geometry",
     doc="""Computes the closest point on the mesh with identifier `id` to the given point in space. Returns ``True`` if a point < ``max_dist`` is found.
 
@@ -1480,7 +1480,7 @@ add_builtin(
         "bary_u": float,
         "bary_v": float,
     },
-    value_type=builtins.bool,
+    value_type=bool,
     group="Geometry",
     doc="""Computes the closest point on the mesh with identifier `id` to the given point in space. Returns ``True`` if a point < ``max_dist`` is found.
 
@@ -1507,7 +1507,7 @@ add_builtin(
         "epsilon": float,
     },
     defaults={"epsilon": 1.0e-3},
-    value_type=builtins.bool,
+    value_type=bool,
     group="Geometry",
     doc="""Computes the closest point on the mesh with identifier `id` to the given point in space. Returns ``True`` if a point < ``max_dist`` is found.
     
@@ -1538,7 +1538,7 @@ add_builtin(
         "threshold": float,
     },
     defaults={"accuracy": 2.0, "threshold": 0.5},
-    value_type=builtins.bool,
+    value_type=bool,
     group="Geometry",
     doc="""Computes the closest point on the mesh with identifier `id` to the given point in space. Returns ``True`` if a point < ``max_dist`` is found. 
     
@@ -1573,7 +1573,7 @@ add_builtin(
         "normal": vec3,
         "face": int,
     },
-    value_type=builtins.bool,
+    value_type=bool,
     group="Geometry",
     doc="""Computes the closest ray hit on the mesh with identifier `id`, returns ``True`` if a point < ``max_t`` is found.
 
@@ -1605,7 +1605,7 @@ add_builtin(
 add_builtin(
     "mesh_query_aabb_next",
     input_types={"query": mesh_query_aabb_t, "index": int},
-    value_type=builtins.bool,
+    value_type=bool,
     group="Geometry",
     doc="""Move to the next triangle overlapping the query bounding box. The index of the current face is stored in ``index``, returns ``False``
    if there are no more overlapping triangles.""",
@@ -1639,7 +1639,7 @@ add_builtin(
 add_builtin(
     "hash_grid_query_next",
     input_types={"query": hash_grid_query_t, "index": int},
-    value_type=builtins.bool,
+    value_type=bool,
     group="Geometry",
     doc="""Move to the next point in the hash grid query. The index of the current neighbor is stored in ``index``, returns ``False``
    if there are no more neighbors.""",
@@ -1751,14 +1751,6 @@ add_builtin(
     value_type=float,
     group="Volumes",
     doc="""Sample the volume given by ``id`` at the volume local-space point ``uvw``. Interpolation should be ``wp.Volume.CLOSEST``, or ``wp.Volume.LINEAR.``""",
-)
-
-add_builtin(
-    "volume_sample_grad_f",
-    input_types={"id": uint64, "uvw": vec3, "sampling_mode": int, "grad": vec3},
-    value_type=float,
-    group="Volumes",
-    doc="""Sample the volume and its gradient given by ``id`` at the volume local-space point ``uvw``. Interpolation should be ``wp.Volume.CLOSEST``, or ``wp.Volume.LINEAR.``""",
 )
 
 add_builtin(
@@ -2135,13 +2127,6 @@ add_builtin(
     doc="Select between two arguments, if cond is false then return ``arg1``, otherwise return ``arg2``",
     group="Utility",
 )
-add_builtin(
-    "select",
-    input_types={"cond": builtins.bool, "arg1": Any, "arg2": Any},
-    value_func=lambda args, kwds, _: args[1].type,
-    doc="Select between two arguments, if cond is false then return ``arg1``, otherwise return ``arg2``",
-    group="Utility",
-)
 for t in int_types:
     add_builtin(
         "select",
@@ -2205,13 +2190,13 @@ def view_value_func(args, kwds, _):
             raise RuntimeError(f"view() index arguments must be of integer type, got index of type {a.type}")
 
     # create an array view with leading dimensions removed
-    dtype = args[0].type.dtype
-    ndim = num_dims - num_indices
-    if isinstance(args[0].type, (fabricarray, indexedfabricarray)):
-        # fabric array of arrays: return array attribute as a regular array
-        return array(dtype=dtype, ndim=ndim)
-    else:
-        return type(args[0].type)(dtype=dtype, ndim=ndim)
+    import copy
+
+    view_type = copy.copy(args[0].type)
+    view_type.ndim -= num_indices
+
+    return view_type
+
 
 # does argument checking and type propagation for store()
 def store_value_func(args, kwds, _):
@@ -2996,10 +2981,9 @@ add_builtin(
     group="Operators",
 )
 
-add_builtin("unot", input_types={"b": builtins.bool}, value_type=builtins.bool, doc="", group="Operators")
-add_builtin("unot", input_types={"b": bool}, value_type=builtins.bool, doc="", group="Operators")
+add_builtin("unot", input_types={"b": bool}, value_type=bool, doc="", group="Operators")
 for t in int_types:
-    add_builtin("unot", input_types={"b": t}, value_type=builtins.bool, doc="", group="Operators")
+    add_builtin("unot", input_types={"b": t}, value_type=bool, doc="", group="Operators")
 
 
-add_builtin("unot", input_types={"a": array(dtype=Any)}, value_type=builtins.bool, doc="", group="Operators")
+add_builtin("unot", input_types={"a": array(dtype=Any)}, value_type=bool, doc="", group="Operators")

--- a/warp/config.py
+++ b/warp/config.py
@@ -5,7 +5,9 @@
 # distribution of this software and related documentation without an express
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 
-version = "1.0.0-beta.2"
+import os
+
+version = "0.10.1"
 
 cuda_path = (
     None  # path to local CUDA toolchain, if None at init time warp will attempt to find the SDK using CUDA_PATH env var

--- a/warp/context.py
+++ b/warp/context.py
@@ -5,24 +5,35 @@
 # distribution of this software and related documentation without an express
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 
-import ast
-import ctypes
-import hashlib
-import inspect
+import math
 import os
-import platform
 import sys
+import hashlib
+import ctypes
+import platform
+import ast
 import types
-from copy import copy as shallowcopy
-from types import ModuleType
-from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple, Union
+import inspect
 
-import numpy as np
+from typing import Tuple
+from typing import List
+from typing import Dict
+from typing import Any
+from typing import Callable
+from typing import Union
+from typing import Mapping
+from typing import Optional
+
+from types import ModuleType
+
+from copy import copy as shallowcopy
 
 import warp
-import warp.build
 import warp.codegen
+import warp.build
 import warp.config
+
+import numpy as np
 
 # represents either a built-in or user-defined function
 
@@ -37,7 +48,6 @@ def create_value_func(type):
 def get_function_args(func):
     """Ensures that all function arguments are annotated and returns a dictionary mapping from argument name to its type."""
     import inspect
-
     argspec = inspect.getfullargspec(func)
 
     # use source-level argument annotations
@@ -70,6 +80,7 @@ class Function:
         custom_replay_func=None,
         skip_forward_codegen=False,
         skip_reverse_codegen=False,
+        overwrite_func_name_by_key=False,
         custom_reverse_num_input_args=-1,
         custom_reverse_mode=False,
         overloaded_annotations=None,
@@ -118,16 +129,21 @@ class Function:
             self.user_templates = {}
             self.user_overloads = {}
 
+            # optionally use the provided key as function name
+            forced_func_name = None
+            if overwrite_func_name_by_key:
+                forced_func_name = key
+
             # user defined (Python) function
             self.adj = warp.codegen.Adjoint(
                 func,
-                is_user_function=True,
                 skip_forward_codegen=skip_forward_codegen,
                 skip_reverse_codegen=skip_reverse_codegen,
+                forced_func_name=forced_func_name,
                 custom_reverse_num_input_args=custom_reverse_num_input_args,
                 custom_reverse_mode=custom_reverse_mode,
                 overload_annotations=overloaded_annotations,
-                transformers=code_transformers,
+                transformers=code_transformers
             )
 
             # record input types
@@ -199,7 +215,7 @@ class Function:
                             x = ValueArg()
 
                             # force conversion to ndarray first (handles tuple / list, Gf.Vec3 case)
-                            if isinstance(a, ctypes.Array) is False:
+                            if isinstance(a, ctypes.Array) == False:
                                 # assume you want the float32 version of the function so it doesn't just
                                 # grab an override for a random data type:
                                 if arg_type._type_ != ctypes.c_float:
@@ -234,7 +250,7 @@ class Function:
                             try:
                                 # try to pack as a scalar type
                                 params.append(arg_type._type_(a))
-                            except Exception:
+                            except:
                                 raise RuntimeError(
                                     f"Error calling function {f.key}, unable to pack function parameter type {type(a)} for param {arg_name}, expected {arg_type}"
                                 )
@@ -334,7 +350,7 @@ class Function:
             # todo: construct a default value for each of the functions args
             # so we can generate the return type for overloaded functions
             return_type = type_str(self.value_func(None, None, None))
-        except Exception:
+        except:
             return False
 
         if return_type.startswith("Tuple"):
@@ -558,7 +574,6 @@ def func_grad(forward_fn):
     adjoint variables of the output variables (if available) of the original function with the same types as the
     output variables. The function must not return anything.
     """
-
     def wrapper(grad_fn):
         generic = any(warp.types.type_is_generic(x) for x in forward_fn.input_types.values())
         if generic:
@@ -571,7 +586,10 @@ def func_grad(forward_fn):
 
         # create temporary Adjoint instance to analyze the function signature
         adj = warp.codegen.Adjoint(
-            grad_fn, skip_forward_codegen=True, skip_reverse_codegen=False, transformers=forward_fn.adj.transformers
+            grad_fn,
+            skip_forward_codegen=True,
+            skip_reverse_codegen=False,
+            transformers=forward_fn.adj.transformers
         )
 
         from warp.types import types_equal
@@ -609,11 +627,11 @@ def func_grad(forward_fn):
                 module=f.module,
                 template_func=f.template_func,
                 skip_forward_codegen=True,
+                overwrite_func_name_by_key=True,
                 custom_reverse_mode=True,
                 custom_reverse_num_input_args=len(f.input_types),
                 skip_adding_overload=False,
-                code_transformers=f.adj.transformers,
-            )
+                code_transformers=f.adj.transformers)
             f.adj.skip_reverse_codegen = True
 
         if hasattr(forward_fn, "user_overloads") and len(forward_fn.user_overloads):
@@ -624,9 +642,7 @@ def func_grad(forward_fn):
                 if match_function(f):
                     add_custom_grad(f)
                     return
-            raise RuntimeError(
-                f"No function overload found for gradient function {grad_fn.__qualname__} for function {forward_fn.key}"
-            )
+            raise RuntimeError(f"No function overload found for gradient function {grad_fn.__qualname__} for function {forward_fn.key}")
         else:
             # resolve return variables
             forward_fn.adj.build(None)
@@ -654,7 +670,6 @@ def func_replay(forward_fn):
     The replay function is the function version that is called in the forward phase of the backward pass (replay mode) and corresponds to the forward function by default.
     The provided function has to match the signature of one of the original forward function overloads.
     """
-
     def wrapper(replay_fn):
         generic = any(warp.types.type_is_generic(x) for x in forward_fn.input_types.values())
         if generic:
@@ -685,9 +700,9 @@ def func_replay(forward_fn):
             module=f.module,
             template_func=f.template_func,
             skip_reverse_codegen=True,
+            overwrite_func_name_by_key=True,
             skip_adding_overload=True,
-            code_transformers=f.adj.transformers,
-        )
+            code_transformers=f.adj.transformers)
 
     return wrapper
 
@@ -831,7 +846,7 @@ def add_builtin(
         def initializer_list_func(args, templates):
             return False
 
-    if defaults is None:
+    if defaults == None:
         defaults = {}
 
     # Add specialized versions of this builtin if it's generic by matching arguments against
@@ -913,7 +928,7 @@ def add_builtin(
                 # This also gives us the return type, which we keep for later:
                 try:
                     return_type = value_func([warp.codegen.Var("", t) for t in argtypes], {}, [])
-                except Exception:
+                except Exception as e:
                     continue
 
                 # The return_type might just be vector_t(length=3,dtype=wp.float32), so we've got to match that
@@ -972,7 +987,7 @@ def add_builtin(
 
         # export means the function will be added to the `warp` module namespace
         # so that users can call it directly from the Python interpreter
-        if export is True:
+        if export == True:
             if hasattr(warp, key):
                 # check that we haven't already created something at this location
                 # if it's just an overload stub for auto-complete then overwrite it
@@ -1057,7 +1072,7 @@ class ModuleBuilder:
         while stack:
             s = stack.pop()
 
-            if s not in structs:
+            if not s in structs:
                 structs.append(s)
 
             for var in s.vars.values():
@@ -1114,9 +1129,7 @@ class ModuleBuilder:
 
         # code-gen all imported functions
         for func in self.functions.keys():
-            source += warp.codegen.codegen_func(
-                func.adj, c_func_name=func.native_func, device=device, options=self.options
-            )
+            source += warp.codegen.codegen_func(func.adj, name=func.key, device=device, options=self.options)
 
         for kernel in self.module.kernels.values():
             # each kernel gets an entry point in the module
@@ -1257,7 +1270,7 @@ class Module:
                     if isinstance(func, warp.context.Function) and func.module is not None:
                         add_ref(func.module)
 
-                except Exception:
+                except:
                     # Lookups may fail for builtins, but that's ok.
                     # Lookups may also fail for functions in this module that haven't been imported yet,
                     # and that's ok too (not an external reference).
@@ -1731,7 +1744,6 @@ class Device:
             self.arch = 0
             self.is_uva = False
             self.is_cubin_supported = False
-            self.is_mempool_supported = False
 
             # TODO: add more device-specific dispatch functions
             self.memset = runtime.core.memset_host
@@ -1744,15 +1756,6 @@ class Device:
             self.is_uva = runtime.core.cuda_device_is_uva(ordinal)
             # check whether our NVRTC can generate CUBINs for this architecture
             self.is_cubin_supported = self.arch in runtime.nvrtc_supported_archs
-            self.is_mempool_supported = runtime.core.cuda_device_is_memory_pool_supported(ordinal)
-
-            # Warn the user of a possible misconfiguration of their system
-            if not self.is_mempool_supported:
-                warp.utils.warn(
-                    f"Support for stream ordered memory allocators was not detected on device {ordinal}. "
-                    "This can prevent the use of graphs and/or result in poor performance. "
-                    "Is the UVM driver enabled?"
-                )
 
             # initialize streams unless context acquisition is postponed
             if self._context is not None:
@@ -2924,7 +2927,7 @@ def full(
             elif na.ndim == 2:
                 dtype = warp.types.matrix(na.shape, scalar_type)
             else:
-                raise ValueError("Values with more than two dimensions are not supported")
+                raise ValueError(f"Values with more than two dimensions are not supported")
         else:
             raise ValueError(f"Invalid value type for Warp array: {value_type}")
 
@@ -3047,34 +3050,8 @@ def empty_like(
     return arr
 
 
-def from_numpy(
-    arr: np.ndarray,
-    dtype: Optional[type] = None,
-    shape: Optional[Sequence[int]] = None,
-    device: Optional[Devicelike] = None,
-    requires_grad: bool = False,
-) -> warp.array:
-    if dtype is None:
-        base_type = warp.types.np_dtype_to_warp_type.get(arr.dtype)
-        if base_type is None:
-            raise RuntimeError("Unsupported NumPy data type '{}'.".format(arr.dtype))
-
-        dim_count = len(arr.shape)
-        if dim_count == 2:
-            dtype = warp.types.vector(length=arr.shape[1], dtype=base_type)
-        elif dim_count == 3:
-            dtype = warp.types.matrix(shape=(arr.shape[1], arr.shape[2]), dtype=base_type)
-        else:
-            dtype = base_type
-
-    return warp.array(
-        data=arr,
-        dtype=dtype,
-        shape=shape,
-        owner=False,
-        device=device,
-        requires_grad=requires_grad,
-    )
+def from_numpy(arr, dtype, device: Devicelike = None, requires_grad=False):
+    return warp.array(data=arr, dtype=dtype, device=device, requires_grad=requires_grad)
 
 
 # given a kernel destination argument type and a value convert
@@ -3135,7 +3112,7 @@ def pack_arg(kernel, arg_type, arg_name, value, device, adjoint=False):
             # try constructing the required value from the argument (handles tuple / list, Gf.Vec3 case)
             try:
                 return arg_type(value)
-            except Exception:
+            except:
                 raise ValueError(f"Failed to convert argument for param {arg_name} to {type_str(arg_type)}")
 
     elif isinstance(value, bool):
@@ -3144,28 +3121,20 @@ def pack_arg(kernel, arg_type, arg_name, value, device, adjoint=False):
     elif isinstance(value, arg_type):
         try:
             # try to pack as a scalar type
-            if arg_type is warp.types.float16:
-                return arg_type._type_(warp.types.float_to_half_bits(value.value))
-            else:
-                return arg_type._type_(value.value)
-        except Exception:
+            return arg_type._type_(value.value)
+        except:
             raise RuntimeError(
-                "Error launching kernel, unable to pack kernel parameter type "
-                f"{type(value)} for param {arg_name}, expected {arg_type}"
+                f"Error launching kernel, unable to pack kernel parameter type {type(value)} for param {arg_name}, expected {arg_type}"
             )
 
     else:
         try:
             # try to pack as a scalar type
-            if arg_type is warp.types.float16:
-                return arg_type._type_(warp.types.float_to_half_bits(value))
-            else:
-                return arg_type._type_(value)
+            return arg_type._type_(value)
         except Exception as e:
             print(e)
             raise RuntimeError(
-                "Error launching kernel, unable to pack kernel parameter type "
-                f"{type(value)} for param {arg_name}, expected {arg_type}"
+                f"Error launching kernel, unable to pack kernel parameter type {type(value)} for param {arg_name}, expected {arg_type}"
             )
 
 
@@ -3317,7 +3286,7 @@ def launch(
         device = runtime.get_device(device)
 
     # check function is a Kernel
-    if isinstance(kernel, Kernel) is False:
+    if isinstance(kernel, Kernel) == False:
         raise RuntimeError("Error launching kernel, can only launch functions decorated with @wp.kernel.")
 
     # debugging aid
@@ -3609,7 +3578,7 @@ def capture_begin(device: Devicelike = None, stream=None, force_module_load=True
 
     """
 
-    if warp.config.verify_cuda is True:
+    if warp.config.verify_cuda == True:
         raise RuntimeError("Cannot use CUDA error verification during graph capture")
 
     if stream is not None:
@@ -3766,16 +3735,6 @@ def copy(
         if src_elem_size != dst_elem_size:
             raise RuntimeError("Incompatible array data types")
 
-        # can't copy to/from fabric arrays of arrays, because they are jagged arrays of arbitrary lengths
-        # TODO?
-        if (
-            isinstance(src, (warp.fabricarray, warp.indexedfabricarray))
-            and src.ndim > 1
-            or isinstance(dest, (warp.fabricarray, warp.indexedfabricarray))
-            and dest.ndim > 1
-        ):
-            raise RuntimeError("Copying to/from Fabric arrays of arrays is not supported")
-
         src_desc = src.__ctype__()
         dst_desc = dest.__ctype__()
         src_ptr = ctypes.pointer(src_desc)
@@ -3811,10 +3770,6 @@ def type_str(t):
         return f"Array[{type_str(t.dtype)}]"
     elif isinstance(t, warp.indexedarray):
         return f"IndexedArray[{type_str(t.dtype)}]"
-    elif isinstance(t, warp.fabricarray):
-        return f"FabricArray[{type_str(t.dtype)}]"
-    elif isinstance(t, warp.indexedfabricarray):
-        return f"IndexedFabricArray[{type_str(t.dtype)}]"
     elif hasattr(t, "_wp_generic_type_str_"):
         generic_type = t._wp_generic_type_str_
 
@@ -3865,7 +3820,7 @@ def print_function(f, file, noentry=False):
         # todo: construct a default value for each of the functions args
         # so we can generate the return type for overloaded functions
         return_type = " -> " + type_str(f.value_func(None, None, None))
-    except Exception:
+    except:
         pass
 
     print(f".. function:: {f.key}({args}){return_type}", file=file)
@@ -3916,14 +3871,14 @@ def print_builtins(file):
     print("\nGeneric Types", file=file)
     print("-------------", file=file)
 
-    print(".. class:: Int", file=file)
-    print(".. class:: Float", file=file)
-    print(".. class:: Scalar", file=file)
-    print(".. class:: Vector", file=file)
-    print(".. class:: Matrix", file=file)
-    print(".. class:: Quaternion", file=file)
-    print(".. class:: Transformation", file=file)
-    print(".. class:: Array", file=file)
+    print(f".. class:: Int", file=file)
+    print(f".. class:: Float", file=file)
+    print(f".. class:: Scalar", file=file)
+    print(f".. class:: Vector", file=file)
+    print(f".. class:: Matrix", file=file)
+    print(f".. class:: Quaternion", file=file)
+    print(f".. class:: Transformation", file=file)
+    print(f".. class:: Array", file=file)
 
     # build dictionary of all functions by group
     groups = {}
@@ -4006,7 +3961,7 @@ def export_stubs(file):
 
             return_str = ""
 
-            if f.export is False or f.hidden is True:  # or f.generic:
+            if f.export == False or f.hidden == True:  # or f.generic:
                 continue
 
             try:
@@ -4016,15 +3971,15 @@ def export_stubs(file):
                 if return_type:
                     return_str = " -> " + type_str(return_type)
 
-            except Exception:
+            except:
                 pass
 
             print("@over", file=file)
             print(f"def {f.key}({args}){return_str}:", file=file)
-            print('    """', file=file)
+            print(f'    """', file=file)
             print(textwrap.indent(text=f.doc, prefix="    "), file=file)
-            print('    """', file=file)
-            print("    ...\n\n", file=file)
+            print(f'    """', file=file)
+            print(f"    ...\n\n", file=file)
 
 
 def export_builtins(file):
@@ -4038,7 +3993,7 @@ def export_builtins(file):
 
     for k, g in builtin_functions.items():
         for f in g.overloads:
-            if f.export is False or f.generic:
+            if f.export == False or f.generic:
                 continue
 
             simple = True
@@ -4061,7 +4016,7 @@ def export_builtins(file):
                 # todo: construct a default value for each of the functions args
                 # so we can generate the return type for overloaded functions
                 return_type = ctype_str(f.value_func(None, None, None))
-            except Exception:
+            except:
                 continue
 
             if return_type.startswith("Tuple"):

--- a/warp/sim/__init__.py
+++ b/warp/sim/__init__.py
@@ -6,7 +6,7 @@
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 
 
-from .model import State, Model, ModelBuilder, Mesh, SDF
+from .model import State, Model, ModelBuilder, Mesh
 
 from .model import GEO_SPHERE
 from .model import GEO_BOX
@@ -47,5 +47,9 @@ from .articulation import eval_fk, eval_ik
 from .import_mjcf import parse_mjcf
 from .import_urdf import parse_urdf
 from .import_snu import parse_snu
+from .import_partnet import parse_partnet_urdf
 from .import_usd import parse_usd
 
+from .utils import quat_from_euler, quat_between_vectors, remesh, load_mesh, plot_graph
+
+from .inertia import transform_inertia

--- a/warp/sim/import_urdf.py
+++ b/warp/sim/import_urdf.py
@@ -5,41 +5,42 @@
 # distribution of this software and related documentation without an express
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 
-import os
-import xml.etree.ElementTree as ET
-from typing import Union
-
 import numpy as np
+import os
+
+import xml.etree.ElementTree as ET
 
 import warp as wp
 from warp.sim.model import Mesh
 
+from typing import Union
+
 
 def parse_urdf(
-    urdf_filename,
-    builder,
-    xform=wp.transform(),
-    floating=False,
-    base_joint: Union[dict, str] = None,
-    density=1000.0,
-    stiffness=100.0,
-    damping=10.0,
-    armature=0.0,
-    shape_ke=1.0e4,
-    shape_kd=1.0e3,
-    shape_kf=1.0e2,
-    shape_mu=0.25,
-    shape_restitution=0.5,
-    shape_thickness=0.0,
-    limit_ke=100.0,
-    limit_kd=10.0,
-    scale=1.0,
-    parse_visuals_as_colliders=False,
-    enable_self_collisions=True,
-    ignore_inertial_definitions=True,
-    ensure_nonstatic_links=True,
-    static_link_mass=1e-2,
-    collapse_fixed_joints=False,
+        urdf_filename,
+        builder,
+        xform=wp.transform(),
+        floating=False,
+        base_joint: Union[dict, str] = None,
+        density=1000.0,
+        stiffness=100.0,
+        damping=10.0,
+        armature=0.0,
+        shape_ke=1.e+4,
+        shape_kd=1.e+3,
+        shape_kf=1.e+2,
+        shape_mu=0.25,
+        shape_restitution=0.5,
+        shape_thickness=0.0,
+        limit_ke=100.0,
+        limit_kd=10.0,
+        scale=1.0,
+        parse_visuals_as_colliders=False,
+        enable_self_collisions=True,
+        ignore_inertial_definitions=True,
+        ensure_nonstatic_links=True,
+        static_link_mass=1e-2,
+        collapse_fixed_joints=False,
 ):
     """
     Parses a URDF file and adds the bodies and joints to the given ModelBuilder.
@@ -75,19 +76,21 @@ def parse_urdf(
     root = file.getroot()
 
     def parse_transform(element):
-        if element is None or element.find("origin") is None:
+        if element is None or element.find('origin') is None:
             return wp.transform()
-        origin = element.find("origin")
-        xyz = origin.get("xyz") or "0 0 0"
-        rpy = origin.get("rpy") or "0 0 0"
+        origin = element.find('origin')
+        xyz = origin.get('xyz') or '0 0 0'
+        rpy = origin.get('rpy') or '0 0 0'
         xyz = [float(x) * scale for x in xyz.split()]
         rpy = [float(x) for x in rpy.split()]
         return wp.transform(xyz, wp.quat_rpy(*rpy))
 
     def parse_shapes(link, collisions, density, incoming_xform=None):
+
         # add geometry
         for collision in collisions:
-            geo = collision.find("geometry")
+
+            geo = collision.find('geometry')
             if geo is None:
                 continue
 
@@ -95,8 +98,8 @@ def parse_urdf(
             if incoming_xform is not None:
                 tf = incoming_xform * tf
 
-            for box in geo.findall("box"):
-                size = box.get("size") or "1 1 1"
+            for box in geo.findall('box'):
+                size = box.get('size') or '1 1 1'
                 size = [float(x) for x in size.split()]
                 builder.add_shape_box(
                     body=link,
@@ -111,31 +114,29 @@ def parse_urdf(
                     kf=shape_kf,
                     mu=shape_mu,
                     restitution=shape_restitution,
-                    thickness=shape_thickness,
-                )
+                    thickness=shape_thickness)
 
-            for sphere in geo.findall("sphere"):
+            for sphere in geo.findall('sphere'):
                 builder.add_shape_sphere(
                     body=link,
                     pos=tf.p,
                     rot=tf.q,
-                    radius=float(sphere.get("radius") or "1") * scale,
+                    radius=float(sphere.get('radius') or '1') * scale,
                     density=density,
                     ke=shape_ke,
                     kd=shape_kd,
                     kf=shape_kf,
                     mu=shape_mu,
                     restitution=shape_restitution,
-                    thickness=shape_thickness,
-                )
+                    thickness=shape_thickness)
 
-            for cylinder in geo.findall("cylinder"):
+            for cylinder in geo.findall('cylinder'):
                 builder.add_shape_capsule(
                     body=link,
                     pos=tf.p,
                     rot=tf.q,
-                    radius=float(cylinder.get("radius") or "1") * scale,
-                    half_height=float(cylinder.get("length") or "1") * 0.5 * scale,
+                    radius=float(cylinder.get('radius') or '1') * scale,
+                    half_height=float(cylinder.get('length') or '1') * 0.5 * scale,
                     density=density,
                     ke=shape_ke,
                     kd=shape_kd,
@@ -143,40 +144,37 @@ def parse_urdf(
                     mu=shape_mu,
                     up_axis=2,  # cylinders in URDF are aligned with z-axis
                     restitution=shape_restitution,
-                    thickness=shape_thickness,
-                )
+                    thickness=shape_thickness)
 
-            for mesh in geo.findall("mesh"):
-                filename = mesh.get("filename")
+            for mesh in geo.findall('mesh'):
+                filename = mesh.get('filename')
                 if filename is None:
                     continue
-                if filename.startswith("http://") or filename.startswith("https://"):
+                if filename.startswith('http://') or filename.startswith('https://'):
                     # download mesh
-                    import shutil
-                    import tempfile
-
                     import requests
-
+                    import tempfile
+                    import shutil
                     with tempfile.TemporaryDirectory() as tmpdir:
                         # get filename extension
                         extension = os.path.splitext(filename)[1]
-                        tmpfile = os.path.join(tmpdir, "mesh" + extension)
+                        tmpfile = os.path.join(tmpdir, 'mesh' + extension)
                         with requests.get(filename, stream=True) as r:
-                            with open(tmpfile, "wb") as f:
+                            with open(tmpfile, 'wb') as f:
                                 shutil.copyfileobj(r.raw, f)
                         filename = tmpfile
                 else:
                     filename = os.path.join(os.path.dirname(urdf_filename), filename)
                 if not os.path.exists(filename):
-                    wp.utils.warn(f"Warning: mesh file {filename} does not exist")
+                    import warnings
+                    warnings.warn(f'Warning: mesh file {filename} does not exist')
                     continue
 
                 import trimesh
-
                 m = trimesh.load_mesh(filename)
-                scaling = mesh.get("scale") or "1 1 1"
+                scaling = mesh.get('scale') or '1 1 1'
                 scaling = np.array([float(x) * scale for x in scaling.split()])
-                if hasattr(m, "geometry"):
+                if hasattr(m, 'geometry'):
                     # multiple meshes are contained in a scene
                     for geom in m.geometry.values():
                         vertices = np.array(geom.vertices, dtype=np.float32) * scaling
@@ -193,8 +191,7 @@ def parse_urdf(
                             kf=shape_kf,
                             mu=shape_mu,
                             restitution=shape_restitution,
-                            thickness=shape_thickness,
-                        )
+                            thickness=shape_thickness)
                 else:
                     # a single mesh
                     vertices = np.array(m.vertices, dtype=np.float32) * scaling
@@ -211,8 +208,7 @@ def parse_urdf(
                         kf=shape_kf,
                         mu=shape_mu,
                         restitution=shape_restitution,
-                        thickness=shape_thickness,
-                    )
+                        thickness=shape_thickness)
 
     # maps from link name -> link index
     link_index = {}
@@ -222,38 +218,42 @@ def parse_urdf(
     start_shape_count = len(builder.shape_geo_type)
 
     # add links
-    for i, urdf_link in enumerate(root.findall("link")):
-        if parse_visuals_as_colliders:
-            colliders = urdf_link.findall("visual")
-        else:
-            colliders = urdf_link.findall("collision")
+    for i, urdf_link in enumerate(root.findall('link')):
 
-        name = urdf_link.get("name")
-        link = builder.add_body(origin=wp.transform_identity(), armature=armature, name=name)
+        if parse_visuals_as_colliders:
+            colliders = urdf_link.findall('visual')
+        else:
+            colliders = urdf_link.findall('collision')
+
+        name = urdf_link.get('name')
+        link = builder.add_body(
+            origin=wp.transform_identity(),
+            armature=armature,
+            name=name)
 
         # add ourselves to the index
         link_index[name] = link
 
         parse_shapes(link, colliders, density=density)
         m = builder.body_mass[link]
-        if not ignore_inertial_definitions and urdf_link.find("inertial") is not None:
+        if not ignore_inertial_definitions and urdf_link.find('inertial') is not None:
             # overwrite inertial parameters if defined
-            inertial = urdf_link.find("inertial")
+            inertial = urdf_link.find('inertial')
             inertial_frame = parse_transform(inertial)
             com = inertial_frame.p
             I_m = np.zeros((3, 3))
-            I_m[0, 0] = float(inertial.find("inertia").get("ixx") or "0") * scale**2
-            I_m[1, 1] = float(inertial.find("inertia").get("iyy") or "0") * scale**2
-            I_m[2, 2] = float(inertial.find("inertia").get("izz") or "0") * scale**2
-            I_m[0, 1] = float(inertial.find("inertia").get("ixy") or "0") * scale**2
-            I_m[0, 2] = float(inertial.find("inertia").get("ixz") or "0") * scale**2
-            I_m[1, 2] = float(inertial.find("inertia").get("iyz") or "0") * scale**2
+            I_m[0, 0] = float(inertial.find('inertia').get('ixx') or '0') * scale**2
+            I_m[1, 1] = float(inertial.find('inertia').get('iyy') or '0') * scale**2
+            I_m[2, 2] = float(inertial.find('inertia').get('izz') or '0') * scale**2
+            I_m[0, 1] = float(inertial.find('inertia').get('ixy') or '0') * scale**2
+            I_m[0, 2] = float(inertial.find('inertia').get('ixz') or '0') * scale**2
+            I_m[1, 2] = float(inertial.find('inertia').get('iyz') or '0') * scale**2
             I_m[1, 0] = I_m[0, 1]
             I_m[2, 0] = I_m[0, 2]
             I_m[2, 1] = I_m[1, 2]
             rot = wp.quat_to_matrix(inertial_frame.q)
             I_m = rot @ I_m
-            m = float(inertial.find("mass").get("value") or "0")
+            m = float(inertial.find('mass').get('value') or '0')
             builder.body_mass[link] = m
             builder.body_inv_mass[link] = 1.0 / m
             builder.body_com[link] = com
@@ -263,7 +263,7 @@ def parse_urdf(
             # set the mass to something nonzero to ensure the body is dynamic
             m = static_link_mass
             # cube with side length 0.5
-            I_m = np.eye(3) * m / 12.0 * (0.5 * scale) ** 2 * 2.0
+            I_m = np.eye(3) * m / 12.0 * (0.5 * scale)**2 * 2.0
             builder.body_mass[link] = m
             builder.body_inv_mass[link] = 1.0 / m
             builder.body_inertia[link] = I_m
@@ -277,37 +277,37 @@ def parse_urdf(
     parent_child_joint = {}
 
     joints = []
-    for joint in root.findall("joint"):
-        parent = joint.find("parent").get("link")
-        child = joint.find("child").get("link")
+    for joint in root.findall('joint'):
+        parent = joint.find('parent').get('link')
+        child = joint.find('child').get('link')
         body_children[parent].append(child)
         joint_data = {
-            "name": joint.get("name"),
-            "parent": parent,
-            "child": child,
-            "type": joint.get("type"),
-            "origin": parse_transform(joint),
-            "damping": damping,
-            "friction": 0.0,
-            "limit_lower": -1.0e6,
-            "limit_upper": 1.0e6,
+            'name': joint.get('name'),
+            'parent': parent,
+            'child': child,
+            'type': joint.get('type'),
+            'origin': parse_transform(joint),
+            'damping': damping,
+            'friction': 0.0,
+            'limit_lower': -1.e6,
+            'limit_upper': 1.e6,
         }
-        if joint.find("axis") is not None:
-            joint_data["axis"] = joint.find("axis").get("xyz")
-            joint_data["axis"] = np.array([float(x) for x in joint_data["axis"].split()])
-        if joint.find("dynamics") is not None:
-            dynamics = joint.find("dynamics")
-            joint_data["damping"] = float(dynamics.get("damping") or str(damping))
-            joint_data["friction"] = float(dynamics.get("friction") or "0")
-        if joint.find("limit") is not None:
-            limit = joint.find("limit")
-            joint_data["limit_lower"] = float(limit.get("lower") or "-1e6")
-            joint_data["limit_upper"] = float(limit.get("upper") or "1e6")
-        if joint.find("mimic") is not None:
-            mimic = joint.find("mimic")
-            joint_data["mimic_joint"] = mimic.get("joint")
-            joint_data["mimic_multiplier"] = float(mimic.get("multiplier") or "1")
-            joint_data["mimic_offset"] = float(mimic.get("offset") or "0")
+        if joint.find('axis') is not None:
+            joint_data['axis'] = joint.find('axis').get('xyz')
+            joint_data['axis'] = np.array([float(x) for x in joint_data['axis'].split()])
+        if joint.find('dynamics') is not None:
+            dynamics = joint.find('dynamics')
+            joint_data['damping'] = float(dynamics.get('damping') or str(damping))
+            joint_data['friction'] = float(dynamics.get('friction') or '0')
+        if joint.find('limit') is not None:
+            limit = joint.find('limit')
+            joint_data['limit_lower'] = float(limit.get('lower') or '-1e6')
+            joint_data['limit_upper'] = float(limit.get('upper') or '1e6')
+        if joint.find('mimic') is not None:
+            mimic = joint.find('mimic')
+            joint_data['mimic_joint'] = mimic.get('joint')
+            joint_data['mimic_multiplier'] = float(mimic.get('multiplier') or '1')
+            joint_data['mimic_offset'] = float(mimic.get('offset') or '0')
 
         parent_child_joint[(parent, child)] = joint_data
         joints.append(joint_data)
@@ -319,7 +319,7 @@ def parse_urdf(
 
     # depth-first search
     def dfs(joint):
-        link = joint["child"]
+        link = joint['child']
         if visited[link]:
             return
         visited[link] = True
@@ -332,12 +332,12 @@ def parse_urdf(
 
     # start DFS from each unvisited joint
     for joint in joints:
-        if not visited[joint["parent"]]:
+        if not visited[joint['parent']]:
             dfs(joint)
 
     # add base joint
     if len(sorted_joints) > 0:
-        base_link_name = sorted_joints[0]["parent"]
+        base_link_name = sorted_joints[0]['parent']
     else:
         base_link_name = next(iter(link_index.keys()))
     root = link_index[base_link_name]
@@ -363,8 +363,7 @@ def parse_urdf(
                 child_xform=base_child_xform,
                 parent=-1,
                 child=root,
-                name="base_joint",
-            )
+                name="base_joint")
         elif isinstance(base_joint, dict):
             base_joint["parent"] = -1
             base_joint["child"] = root
@@ -374,8 +373,7 @@ def parse_urdf(
             builder.add_joint(**base_joint)
         else:
             raise ValueError(
-                "base_joint must be a comma-separated string of joint axes or a dict with joint parameters"
-            )
+                "base_joint must be a comma-separated string of joint axes or a dict with joint parameters")
     elif floating:
         builder.add_joint_free(root, name="floating_base")
 
@@ -395,17 +393,17 @@ def parse_urdf(
 
     # add joints, in topological order starting from root body
     for joint in sorted_joints:
-        parent = link_index[joint["parent"]]
-        child = link_index[joint["child"]]
+        parent = link_index[joint['parent']]
+        child = link_index[joint['child']]
         if child == -1:
             # we skipped the insertion of the child body
             continue
 
-        lower = joint["limit_lower"]
-        upper = joint["limit_upper"]
-        joint_damping = joint["damping"]
+        lower = joint['limit_lower']
+        upper = joint['limit_upper']
+        joint_damping = joint['damping']
 
-        parent_xform = joint["origin"]
+        parent_xform = joint['origin']
         child_xform = wp.transform_identity()
 
         joint_mode = wp.sim.JOINT_MODE_LIMIT
@@ -417,40 +415,32 @@ def parse_urdf(
             child=child,
             parent_xform=parent_xform,
             child_xform=child_xform,
-            name=joint["name"],
+            name=joint['name'],
         )
 
-        if joint["type"] == "revolute" or joint["type"] == "continuous":
+        if joint['type'] == "revolute" or joint['type'] == "continuous":
             builder.add_joint_revolute(
-                axis=joint["axis"],
-                target_ke=stiffness,
-                target_kd=joint_damping,
-                limit_lower=lower,
-                limit_upper=upper,
-                limit_ke=limit_ke,
-                limit_kd=limit_kd,
+                axis=joint['axis'],
+                target_ke=stiffness, target_kd=joint_damping,
+                limit_lower=lower, limit_upper=upper,
+                limit_ke=limit_ke, limit_kd=limit_kd,
                 mode=joint_mode,
-                **joint_params,
-            )
-        elif joint["type"] == "prismatic":
+                **joint_params)
+        elif joint['type'] == "prismatic":
             builder.add_joint_prismatic(
-                axis=joint["axis"],
-                target_ke=stiffness,
-                target_kd=joint_damping,
-                limit_lower=lower * scale,
-                limit_upper=upper * scale,
-                limit_ke=limit_ke,
-                limit_kd=limit_kd,
+                axis=joint['axis'],
+                target_ke=stiffness, target_kd=joint_damping,
+                limit_lower=lower * scale, limit_upper=upper * scale,
+                limit_ke=limit_ke, limit_kd=limit_kd,
                 mode=joint_mode,
-                **joint_params,
-            )
-        elif joint["type"] == "fixed":
+                **joint_params)
+        elif joint['type'] == "fixed":
             builder.add_joint_fixed(**joint_params)
-        elif joint["type"] == "floating":
+        elif joint['type'] == "floating":
             builder.add_joint_free(**joint_params)
-        elif joint["type"] == "planar":
+        elif joint['type'] == "planar":
             # find plane vectors perpendicular to axis
-            axis = np.array(joint["axis"])
+            axis = np.array(joint['axis'])
             axis /= np.linalg.norm(axis)
 
             # create helper vector that is not parallel to the axis
@@ -471,10 +461,9 @@ def parse_urdf(
                         v, limit_lower=lower * scale, limit_upper=upper * scale, limit_ke=limit_ke, limit_kd=limit_kd
                     ),
                 ],
-                **joint_params,
-            )
+                **joint_params)
         else:
-            raise Exception("Unsupported joint type: " + joint["type"])
+            raise Exception("Unsupported joint type: " + joint['type'])
 
     if not enable_self_collisions:
         for i in range(start_shape_count, end_shape_count):

--- a/warp/sim/import_usd.py
+++ b/warp/sim/import_usd.py
@@ -700,9 +700,9 @@ def parse_usd(
                 face_id = 0
                 for count in counts:
                     if count == 3:
-                        faces.append(indices[face_id : face_id + 3])
+                        faces.append(indices[face_id: face_id + 3])
                     elif count == 4:
-                        faces.append(indices[face_id : face_id + 3])
+                        faces.append(indices[face_id: face_id + 3])
                         faces.append(indices[[face_id, face_id + 2, face_id + 3]])
                     else:
                         # assert False, f"Error while parsing USD mesh {path}: encountered polygon with {count} vertices, but only triangles and quads are supported."

--- a/warp/sim/inertia.py
+++ b/warp/sim/inertia.py
@@ -33,7 +33,7 @@ def triangle_inertia(
 
     Dm = wp.mat33(pcom[0], qcom[0], rcom[0], pcom[1], qcom[1], rcom[1], pcom[2], qcom[2], rcom[2])
 
-    volume = wp.determinant(Dm) / 6.0
+    volume = wp.abs(wp.determinant(Dm) / 6.0)
 
     # accumulate mass
     wp.atomic_add(mass, 0, 4.0 * density * volume)
@@ -261,6 +261,7 @@ def compute_mesh_inertia(
     com = np.mean(vertices, 0)
     com_warp = wp.vec3(com[0], com[1], com[2])
 
+    indices = np.array(indices).flatten()
     num_tris = len(indices) // 3
 
     # compute signed inertia for each tetrahedron
@@ -304,9 +305,9 @@ def compute_mesh_inertia(
         )
 
     # Extract mass and inertia and save to class attributes.
-    mass = mass_warp.numpy()[0] * density
+    mass = float(mass_warp.numpy()[0] * density)
     I = I_warp.numpy()[0] * density
-    volume = vol_warp.numpy()[0]
+    volume = float(vol_warp.numpy()[0])
     return mass, com, I, volume
 
 

--- a/warp/sim/particles.py
+++ b/warp/sim/particles.py
@@ -89,7 +89,7 @@ def eval_particle_forces_kernel(
 
 
 def eval_particle_forces(model, state, forces):
-    if model.particle_max_radius > 0.0:
+    if model.particle_count > 1 and model.particle_max_radius > 0.0:
         wp.launch(
             kernel=eval_particle_forces_kernel,
             dim=model.particle_count,

--- a/warp/sim/utils.py
+++ b/warp/sim/utils.py
@@ -1,4 +1,7 @@
 import warp as wp
+import numpy as np
+
+from typing import Tuple, List
 
 PI = wp.constant(3.14159265359)
 PI_2 = wp.constant(1.57079632679)
@@ -63,7 +66,7 @@ def quat_decompose(q: wp.quat):
 @wp.func
 def quat_to_rpy(q: wp.quat):
     """
-    Convert a quaternion into euler angles (roll, pitch, yaw)
+    Convert a quaternion into Euler angles (roll, pitch, yaw)
     roll is rotation around x in radians (counterclockwise)
     pitch is rotation around y in radians (counterclockwise)
     yaw is rotation around z in radians (counterclockwise)
@@ -90,7 +93,7 @@ def quat_to_rpy(q: wp.quat):
 @wp.func
 def quat_to_euler(q: wp.quat, i: int, j: int, k: int) -> wp.vec3:
     """
-    Convert a quaternion into euler angles
+    Convert a quaternion into Euler angles
     i, j, k are the indices in [1,2,3] of the axes to use
     (i != j, j != k)
     """
@@ -125,6 +128,50 @@ def quat_to_euler(q: wp.quat, i: int, j: int, k: int) -> wp.vec3:
         t2 -= PI_2
         t3 *= e
     return wp.vec3(t1, t2, t3)
+
+
+@wp.func
+def quat_from_euler(e: wp.vec3, i: int, j: int, k: int) -> wp.quat:
+    """
+    Convert Euler angles into a quaternion
+    i, j, k are the indices in [1,2,3] of the axes to use
+    (i != j, j != k)
+    """
+    qx = wp.quat(1.0, 0.0, 0.0, e[0])
+    qy = wp.quat(0.0, 1.0, 0.0, e[1])
+    qz = wp.quat(0.0, 0.0, 1.0, e[2])
+    if i == 1:
+        qi = qx
+    elif i == 2:
+        qi = qy
+    else:
+        qi = qz
+    if j == 1:
+        qj = qx
+    elif j == 2:
+        qj = qy
+    else:
+        qj = qz
+    if k == 1:
+        qk = qx
+    elif k == 2:
+        qk = qy
+    else:
+        qk = qz
+    return qi * qj * qk
+
+
+@wp.func
+def quat_between_vectors(a: wp.vec3, b: wp.vec3) -> wp.quat:
+    """
+    Compute the quaternion that rotates vector a to vector b
+    """
+    a = wp.normalize(a)
+    b = wp.normalize(b)
+    c = wp.cross(a, b)
+    d = wp.dot(a, b)
+    q = wp.quat(c[0], c[1], c[2], 1.0 + d)
+    return wp.normalize(q)
 
 
 @wp.func
@@ -196,4 +243,240 @@ def vec_abs(a: wp.vec3):
     return wp.vec3(wp.abs(a[0]), wp.abs(a[1]), wp.abs(a[2]))
 
 
-        
+def load_mesh(filename, use_meshio=True):
+    """
+    Loads a 3D triangular surface mesh from a file.
+
+    Args:
+        filename: The path to the 3D model file (obj, and other formats supported by meshio/openmesh) to load.
+        use_meshio: If True, use meshio to load the mesh. Otherwise, use openmesh.
+
+    Returns:
+        Tuple of (mesh_points, mesh_indices), where mesh_points is a Nx3 numpy array of vertex positions (float32),
+        and mesh_indices is a Mx3 numpy array of vertex indices (int32) for the triangular faces.
+    """
+    if use_meshio:
+        import meshio
+
+        m = meshio.read(filename)
+        mesh_points = np.array(m.points)
+        mesh_indices = np.array(m.cells[0].data, dtype=np.int32)
+    else:
+        import openmesh
+
+        m = openmesh.read_trimesh(filename)
+        mesh_points = np.array(m.points())
+        mesh_indices = np.array(m.face_vertex_indices(), dtype=np.int32)
+    return mesh_points, mesh_indices
+
+
+def visualize_meshes(
+    meshes: List[Tuple[list, list]], num_cols=0, num_rows=0, titles=[], scale_axes=True, show_plot=True
+):
+    # render meshes in a grid with matplotlib
+    import matplotlib.pyplot as plt
+    from mpl_toolkits.mplot3d import Axes3D
+
+    num_cols = min(num_cols, len(meshes))
+    num_rows = min(num_rows, len(meshes))
+    if num_cols and not num_rows:
+        num_rows = int(np.ceil(len(meshes) / num_cols))
+    elif num_rows and not num_cols:
+        num_cols = int(np.ceil(len(meshes) / num_rows))
+    else:
+        num_cols = len(meshes)
+        num_rows = 1
+
+    vertices = [np.array(v).reshape((-1, 3)) for v, _ in meshes]
+    faces = [np.array(f, dtype=np.int32).reshape((-1, 3)) for _, f in meshes]
+    if scale_axes:
+        ranges = np.array([v.max(axis=0) - v.min(axis=0) for v in vertices])
+        max_range = ranges.max()
+        mid_points = np.array([v.max(axis=0) + v.min(axis=0) for v in vertices]) * 0.5
+
+    fig = plt.figure(figsize=(12, 6))
+    for i, (vertices, faces) in enumerate(meshes):
+        ax = fig.add_subplot(num_rows, num_cols, i + 1, projection="3d")
+        if i < len(titles):
+            ax.set_title(titles[i])
+        ax.plot_trisurf(vertices[:, 0], vertices[:, 1], vertices[:, 2], triangles=faces, edgecolor="k")
+        if scale_axes:
+            mid = mid_points[i]
+            ax.set_xlim(mid[0] - max_range, mid[0] + max_range)
+            ax.set_ylim(mid[1] - max_range, mid[1] + max_range)
+            ax.set_zlim(mid[2] - max_range, mid[2] + max_range)
+    if show_plot:
+        plt.show()
+    return fig
+
+
+def remesh_ftetwild(vertices, faces, stop_quality=10, max_its=50, edge_length_r=0.1, epsilon=0.01):
+    """
+    Remeshes a 3D triangular surface mesh using "Fast Tetrahedral Meshing in the Wild" (fTetWild).
+    This is useful for improving the quality of the mesh, and for ensuring that the mesh is
+    watertight. This function first tetrahedralizes the mesh, then extracts the surface mesh.
+    The resulting mesh is guaranteed to be watertight and may have a different topology than the
+    input mesh.
+
+    This function requires that wildmeshing is installed, see
+    https://wildmeshing.github.io/python/ for installation instructions.
+
+    Args:
+        vertices: A numpy array of shape (N, 3) containing the vertex positions.
+        faces: A numpy array of shape (M, 3) containing the vertex indices of the faces.
+        stop_quality: The maximum AMIPS energy for stopping mesh optimization.
+        max_its: The maximum number of mesh optimization iterations.
+        edge_length_r: The relative target edge length as a fraction of the bounding box diagonal.
+        epsilon: The relative envelope size as a fraction of the bounding box diagonal.
+        visualize: If True, visualize the input mesh next to the remeshed result using matplotlib.
+
+    Returns:
+        A tuple (vertices, faces) containing the remeshed mesh. Returns the original vertices and faces
+        if the remeshing fails.
+    """
+    import wildmeshing as wm
+    from collections import defaultdict
+
+    tetra = wm.Tetrahedralizer(stop_quality=stop_quality, max_its=max_its, edge_length_r=edge_length_r, epsilon=epsilon)
+    tetra.set_mesh(vertices, np.array(faces).reshape(-1, 3))
+    tetra.tetrahedralize()
+    tet_vertices, tet_indices = tetra.get_tet_mesh()
+
+    def face_indices(tet):
+        face1 = (tet[0], tet[2], tet[1])
+        face2 = (tet[1], tet[2], tet[3])
+        face3 = (tet[0], tet[1], tet[3])
+        face4 = (tet[0], tet[3], tet[2])
+        return (
+            (face1, tuple(sorted(face1))),
+            (face2, tuple(sorted(face2))),
+            (face3, tuple(sorted(face3))),
+            (face4, tuple(sorted(face4))),
+        )
+
+    # determine surface faces
+    elements_per_face = defaultdict(set)
+    unique_faces = {}
+    for e, tet in enumerate(tet_indices):
+        for face, key in face_indices(tet):
+            elements_per_face[key].add(e)
+            unique_faces[key] = face
+    surface_faces = [face for key, face in unique_faces.items() if len(elements_per_face[key]) == 1]
+
+    new_vertices = np.array(tet_vertices)
+    new_faces = np.array(surface_faces, dtype=np.int32)
+
+    if len(new_vertices) == 0 or len(new_faces) == 0:
+        import warnings
+
+        warnings.warn("Remeshing failed, the optimized mesh has no vertices or faces; return previous mesh.")
+        return vertices, faces
+
+    return new_vertices, new_faces
+
+
+def remesh_alphashape(vertices, faces=None, alpha=3.0):
+    """
+    Remeshes a 3D triangular surface mesh using the alpha shape algorithm.
+
+    Args:
+        vertices: A numpy array of shape (N, 3) containing the vertex positions.
+        faces: A numpy array of shape (M, 3) containing the vertex indices of the faces (not needed).
+        alpha: The alpha shape parameter.
+
+    Returns:
+        A tuple (vertices, faces) containing the remeshed mesh.
+    """
+    import alphashape
+
+    alpha_shape = alphashape.alphashape(vertices, alpha)
+    return np.array(alpha_shape.vertices), np.array(alpha_shape.faces, dtype=np.int32)
+
+
+def remesh(vertices, faces, method="ftetwild", visualize=False, **remeshing_kwargs):
+    """
+    Remeshes a 3D triangular surface mesh using the specified method.
+
+    Args:
+        vertices: A numpy array of shape (N, 3) containing the vertex positions.
+        faces: A numpy array of shape (M, 3) containing the vertex indices of the faces.
+        method: The remeshing method to use. One of "ftetwild" or "alphashape".
+        visualize: Whether to render the input and output meshes using matplotlib.
+        **remeshing_kwargs: Additional keyword arguments passed to the remeshing function.
+
+    Returns:
+        A tuple (vertices, faces) containing the remeshed mesh.
+    """
+    if method == "ftetwild":
+        new_vertices, new_faces = remesh_ftetwild(vertices, faces, **remeshing_kwargs)
+    elif method == "alphashape":
+        new_vertices, new_faces = remesh_alphashape(vertices, faces, **remeshing_kwargs)
+    # TODO add poisson sampling (trimesh has implementation at https://trimsh.org/trimesh.sample.html)
+    else:
+        raise ValueError(f"Unknown remeshing method: {method}")
+
+    if visualize:
+        # side-by-side visualization of the input and output meshes
+        visualize_meshes([(vertices, faces), (new_vertices, new_faces)], titles=["Original", "Remeshed"])
+    return new_vertices, new_faces
+
+
+def plot_graph(vertices, edges, edge_labels=[]):
+    """
+    Plots a graph using matplotlib.
+
+    Args:
+        vertices: A numpy array of shape (N, 3) containing the vertex positions.
+        edges: A numpy array of shape (M, 2) containing the vertex indices of the edges.
+        edge_labels: A list of edge labels.
+    """
+    import matplotlib.pyplot as plt
+    import networkx as nx
+
+    G = nx.DiGraph()
+    name_to_index = {}
+    for i, name in enumerate(vertices):
+        G.add_node(i)
+        name_to_index[name] = i
+    g_edge_labels = {}
+    for i, (a, b) in enumerate(edges):
+        a = a if isinstance(a, int) else name_to_index[a]
+        b = b if isinstance(b, int) else name_to_index[b]
+        label = None
+        if i < len(edge_labels):
+            label = edge_labels[i]
+            g_edge_labels[(a, b)] = label
+        G.add_edge(a, b, label=label)
+
+    # try:
+    #     pos = nx.nx_agraph.graphviz_layout(
+    #         G, prog='neato', args='-Gnodesep="10" -Granksep="10"')
+    # except:
+    #     print(
+    #         "Warning: could not use graphviz to layout graph. Falling back to spring layout.")
+    #     print("To get better layouts, install graphviz and pygraphviz.")
+    #     pos = nx.spring_layout(G, k=3.5, iterations=200)
+    #     # pos = nx.kamada_kawai_layout(G, scale=1.5)
+    #     # pos = nx.spectral_layout(G, scale=1.5)
+    pos = nx.nx_agraph.graphviz_layout(G, prog="neato", args='-Gnodesep="20" -Granksep="20"')
+
+    default_draw_args = dict(alpha=0.9, edgecolors="black", linewidths=0.5)
+    nx.draw_networkx_nodes(G, pos, **default_draw_args)
+    nx.draw_networkx_labels(
+        G,
+        pos,
+        labels={i: v for i, v in enumerate(vertices)},
+        font_size=8,
+        bbox=dict(facecolor="white", alpha=0.8, edgecolor="none", pad=0.5),
+    )
+
+    nx.draw_networkx_edges(G, pos, edgelist=G.edges(), arrows=True, edge_color="black", node_size=1000)
+    nx.draw_networkx_edge_labels(
+        G,
+        pos,
+        edge_labels=g_edge_labels,
+        font_color="darkslategray",
+        font_size=8,
+    )
+    plt.axis("off")
+    plt.show()

--- a/warp/sparse.py
+++ b/warp/sparse.py
@@ -202,13 +202,13 @@ def bsr_assign(dest: BsrMatrix, src: BsrMatrix):
     _bsr_ensure_fits(dest)
 
     wp.copy(dest=dest.offsets, src=src.offsets, count=src.nrow + 1)
-    if src.nnz > 0:
-        wp.copy(dest=dest.columns, src=src.columns, count=src.nnz)
-        warp.utils.array_cast(out_array=dest.values, in_array=src.values, count=src.nnz)
+    wp.copy(dest=dest.columns, src=src.columns, count=src.nnz)
+
+    warp.utils.array_cast(out_array=dest.values, in_array=src.values, count=src.nnz)
 
 
 def bsr_copy(A: BsrMatrix, scalar_type=None):
-    """Returns a copy of matrix A, possibly casting values to a new scalar type"""
+    """Returns a copy of matrix A, possibly asting values to a new scalar type"""
     if scalar_type is None:
         block_type = A.values.dtype
     elif A.block_shape == (1, 1):
@@ -665,23 +665,16 @@ def bsr_mm(x: BsrMatrix, y: BsrMatrix, z: BsrMatrix = None, alpha: float = 1.0, 
         inputs=[0, beta, mm_rows, mm_cols, z.offsets, z.columns, z.values, mm_values],
     )
 
-    # Update z to point to result blocks
-    z.values = mm_values
-    z.nnz = mm_nnz
-
-    # Add mm blocks to z values
-
-    if z.block_shape == (1, 1) and x.block_shape != (1, 1):
-        # Result block type is scalar, but operands are matrices
-        # Cast result to (1x1) matrix to perform multiplication
-        mm_values = mm_values.view(wp.types.matrix(shape=(1, 1), dtype=z.scalar_type))
-
+    # Add mm blocks
     wp.launch(
         kernel=_bsr_mm_compute_values,
         device=device,
         dim=z.nrow,
         inputs=[alpha, x.offsets, x.columns, x.values, y.offsets, y.columns, y.values, z.offsets, z.columns, mm_values],
     )
+
+    z.values = mm_values
+    z.nnz = mm_nnz
 
     return z
 

--- a/warp/stubs.py
+++ b/warp/stubs.py
@@ -23,9 +23,8 @@ Array = Generic[DType]
 
 from warp.types import array, array1d, array2d, array3d, array4d, constant
 from warp.types import indexedarray, indexedarray1d, indexedarray2d, indexedarray3d, indexedarray4d
-from warp.fabric import fabricarray, fabricarrayarray, indexedfabricarray, indexedfabricarrayarray
 
-from warp.types import bool, int8, uint8, int16, uint16, int32, uint32, int64, uint64, float16, float32, float64
+from warp.types import int8, uint8, int16, uint16, int32, uint32, int64, uint64, float16, float32, float64
 from warp.types import vec2, vec2b, vec2ub, vec2s, vec2us, vec2i, vec2ui, vec2l, vec2ul, vec2h, vec2f, vec2d
 from warp.types import vec3, vec3b, vec3ub, vec3s, vec3us, vec3i, vec3ui, vec3l, vec3ul, vec3h, vec3f, vec3d
 from warp.types import vec4, vec4b, vec4ub, vec4s, vec4us, vec4i, vec4ui, vec4l, vec4ul, vec4h, vec4f, vec4d
@@ -45,7 +44,7 @@ from warp.types import matmul, adj_matmul, batched_matmul, adj_batched_matmul, f
 from warp.types import vector as vec
 from warp.types import matrix as mat
 
-from warp.context import init, func, func_grad, func_replay, kernel, struct, overload
+from warp.context import init, func, kernel, struct, overload
 from warp.context import is_cpu_available, is_cuda_available, is_device_available
 from warp.context import get_devices, get_preferred_device
 from warp.context import get_cuda_devices, get_cuda_device_count, get_cuda_device, map_cuda_device, unmap_cuda_device
@@ -89,10 +88,6 @@ from warp.dlpack import from_dlpack, to_dlpack
 from warp.constants import *
 
 from . import builtins
-
-import warp.config
-
-__version__ = warp.config.version
 
 
 @over
@@ -1145,14 +1140,6 @@ def volume_sample_f(id: uint64, uvw: vec3f, sampling_mode: int32) -> float:
 
 
 @over
-def volume_sample_grad_f(id: uint64, uvw: vec3f, sampling_mode: int32, grad: vec3f) -> float:
-    """
-    Sample the volume and its gradient given by ``id`` at the volume local-space point ``uvw``. Interpolation should be ``wp.Volume.CLOSEST``, or ``wp.Volume.LINEAR.``
-    """
-    ...
-
-
-@over
 def volume_lookup_f(id: uint64, i: int32, j: int32, k: int32) -> float:
     """
     Returns the value of voxel with coordinates ``i``, ``j``, ``k``, if the voxel at this index does not exist this function returns the background value
@@ -1535,14 +1522,6 @@ def select(cond: bool, arg1: Any, arg2: Any):
 
 
 @over
-def select(cond: bool, arg1: Any, arg2: Any):
-    """
-    Select between two arguments, if cond is false then return ``arg1``, otherwise return ``arg2``
-    """
-    ...
-
-
-@over
 def select(cond: int8, arg1: Any, arg2: Any):
     """
     Select between two arguments, if cond is false then return ``arg1``, otherwise return ``arg2``
@@ -1647,70 +1626,6 @@ def atomic_add(a: Array[Any], i: int32, j: int32, k: int32, l: int32, value: Any
 
 
 @over
-def atomic_add(a: FabricArray[Any], i: int32, value: Any):
-    """
-    Atomically add ``value`` onto the array at location given by index.
-    """
-    ...
-
-
-@over
-def atomic_add(a: FabricArray[Any], i: int32, j: int32, value: Any):
-    """
-    Atomically add ``value`` onto the array at location given by indices.
-    """
-    ...
-
-
-@over
-def atomic_add(a: FabricArray[Any], i: int32, j: int32, k: int32, value: Any):
-    """
-    Atomically add ``value`` onto the array at location given by indices.
-    """
-    ...
-
-
-@over
-def atomic_add(a: FabricArray[Any], i: int32, j: int32, k: int32, l: int32, value: Any):
-    """
-    Atomically add ``value`` onto the array at location given by indices.
-    """
-    ...
-
-
-@over
-def atomic_add(a: IndexedFabricArray[Any], i: int32, value: Any):
-    """
-    Atomically add ``value`` onto the array at location given by index.
-    """
-    ...
-
-
-@over
-def atomic_add(a: IndexedFabricArray[Any], i: int32, j: int32, value: Any):
-    """
-    Atomically add ``value`` onto the array at location given by indices.
-    """
-    ...
-
-
-@over
-def atomic_add(a: IndexedFabricArray[Any], i: int32, j: int32, k: int32, value: Any):
-    """
-    Atomically add ``value`` onto the array at location given by indices.
-    """
-    ...
-
-
-@over
-def atomic_add(a: IndexedFabricArray[Any], i: int32, j: int32, k: int32, l: int32, value: Any):
-    """
-    Atomically add ``value`` onto the array at location given by indices.
-    """
-    ...
-
-
-@over
 def atomic_sub(a: Array[Any], i: int32, value: Any):
     """
     Atomically subtract ``value`` onto the array at location given by index.
@@ -1736,70 +1651,6 @@ def atomic_sub(a: Array[Any], i: int32, j: int32, k: int32, value: Any):
 
 @over
 def atomic_sub(a: Array[Any], i: int32, j: int32, k: int32, l: int32, value: Any):
-    """
-    Atomically subtract ``value`` onto the array at location given by indices.
-    """
-    ...
-
-
-@over
-def atomic_sub(a: FabricArray[Any], i: int32, value: Any):
-    """
-    Atomically subtract ``value`` onto the array at location given by index.
-    """
-    ...
-
-
-@over
-def atomic_sub(a: FabricArray[Any], i: int32, j: int32, value: Any):
-    """
-    Atomically subtract ``value`` onto the array at location given by indices.
-    """
-    ...
-
-
-@over
-def atomic_sub(a: FabricArray[Any], i: int32, j: int32, k: int32, value: Any):
-    """
-    Atomically subtract ``value`` onto the array at location given by indices.
-    """
-    ...
-
-
-@over
-def atomic_sub(a: FabricArray[Any], i: int32, j: int32, k: int32, l: int32, value: Any):
-    """
-    Atomically subtract ``value`` onto the array at location given by indices.
-    """
-    ...
-
-
-@over
-def atomic_sub(a: IndexedFabricArray[Any], i: int32, value: Any):
-    """
-    Atomically subtract ``value`` onto the array at location given by index.
-    """
-    ...
-
-
-@over
-def atomic_sub(a: IndexedFabricArray[Any], i: int32, j: int32, value: Any):
-    """
-    Atomically subtract ``value`` onto the array at location given by indices.
-    """
-    ...
-
-
-@over
-def atomic_sub(a: IndexedFabricArray[Any], i: int32, j: int32, k: int32, value: Any):
-    """
-    Atomically subtract ``value`` onto the array at location given by indices.
-    """
-    ...
-
-
-@over
-def atomic_sub(a: IndexedFabricArray[Any], i: int32, j: int32, k: int32, l: int32, value: Any):
     """
     Atomically subtract ``value`` onto the array at location given by indices.
     """
@@ -1839,70 +1690,6 @@ def atomic_min(a: Array[Any], i: int32, j: int32, k: int32, l: int32, value: Any
 
 
 @over
-def atomic_min(a: FabricArray[Any], i: int32, value: Any):
-    """
-    Compute the minimum of ``value`` and ``array[index]`` and atomically update the array. Note that for vectors and matrices the operation is only atomic on a per-component basis.
-    """
-    ...
-
-
-@over
-def atomic_min(a: FabricArray[Any], i: int32, j: int32, value: Any):
-    """
-    Compute the minimum of ``value`` and ``array[index]`` and atomically update the array. Note that for vectors and matrices the operation is only atomic on a per-component basis.
-    """
-    ...
-
-
-@over
-def atomic_min(a: FabricArray[Any], i: int32, j: int32, k: int32, value: Any):
-    """
-    Compute the minimum of ``value`` and ``array[index]`` and atomically update the array. Note that for vectors and matrices the operation is only atomic on a per-component basis.
-    """
-    ...
-
-
-@over
-def atomic_min(a: FabricArray[Any], i: int32, j: int32, k: int32, l: int32, value: Any):
-    """
-    Compute the minimum of ``value`` and ``array[index]`` and atomically update the array. Note that for vectors and matrices the operation is only atomic on a per-component basis.
-    """
-    ...
-
-
-@over
-def atomic_min(a: IndexedFabricArray[Any], i: int32, value: Any):
-    """
-    Compute the minimum of ``value`` and ``array[index]`` and atomically update the array. Note that for vectors and matrices the operation is only atomic on a per-component basis.
-    """
-    ...
-
-
-@over
-def atomic_min(a: IndexedFabricArray[Any], i: int32, j: int32, value: Any):
-    """
-    Compute the minimum of ``value`` and ``array[index]`` and atomically update the array. Note that for vectors and matrices the operation is only atomic on a per-component basis.
-    """
-    ...
-
-
-@over
-def atomic_min(a: IndexedFabricArray[Any], i: int32, j: int32, k: int32, value: Any):
-    """
-    Compute the minimum of ``value`` and ``array[index]`` and atomically update the array. Note that for vectors and matrices the operation is only atomic on a per-component basis.
-    """
-    ...
-
-
-@over
-def atomic_min(a: IndexedFabricArray[Any], i: int32, j: int32, k: int32, l: int32, value: Any):
-    """
-    Compute the minimum of ``value`` and ``array[index]`` and atomically update the array. Note that for vectors and matrices the operation is only atomic on a per-component basis.
-    """
-    ...
-
-
-@over
 def atomic_max(a: Array[Any], i: int32, value: Any):
     """
     Compute the maximum of ``value`` and ``array[index]`` and atomically update the array. Note that for vectors and matrices the operation is only atomic on a per-component basis.
@@ -1928,70 +1715,6 @@ def atomic_max(a: Array[Any], i: int32, j: int32, k: int32, value: Any):
 
 @over
 def atomic_max(a: Array[Any], i: int32, j: int32, k: int32, l: int32, value: Any):
-    """
-    Compute the maximum of ``value`` and ``array[index]`` and atomically update the array. Note that for vectors and matrices the operation is only atomic on a per-component basis.
-    """
-    ...
-
-
-@over
-def atomic_max(a: FabricArray[Any], i: int32, value: Any):
-    """
-    Compute the maximum of ``value`` and ``array[index]`` and atomically update the array. Note that for vectors and matrices the operation is only atomic on a per-component basis.
-    """
-    ...
-
-
-@over
-def atomic_max(a: FabricArray[Any], i: int32, j: int32, value: Any):
-    """
-    Compute the maximum of ``value`` and ``array[index]`` and atomically update the array. Note that for vectors and matrices the operation is only atomic on a per-component basis.
-    """
-    ...
-
-
-@over
-def atomic_max(a: FabricArray[Any], i: int32, j: int32, k: int32, value: Any):
-    """
-    Compute the maximum of ``value`` and ``array[index]`` and atomically update the array. Note that for vectors and matrices the operation is only atomic on a per-component basis.
-    """
-    ...
-
-
-@over
-def atomic_max(a: FabricArray[Any], i: int32, j: int32, k: int32, l: int32, value: Any):
-    """
-    Compute the maximum of ``value`` and ``array[index]`` and atomically update the array. Note that for vectors and matrices the operation is only atomic on a per-component basis.
-    """
-    ...
-
-
-@over
-def atomic_max(a: IndexedFabricArray[Any], i: int32, value: Any):
-    """
-    Compute the maximum of ``value`` and ``array[index]`` and atomically update the array. Note that for vectors and matrices the operation is only atomic on a per-component basis.
-    """
-    ...
-
-
-@over
-def atomic_max(a: IndexedFabricArray[Any], i: int32, j: int32, value: Any):
-    """
-    Compute the maximum of ``value`` and ``array[index]`` and atomically update the array. Note that for vectors and matrices the operation is only atomic on a per-component basis.
-    """
-    ...
-
-
-@over
-def atomic_max(a: IndexedFabricArray[Any], i: int32, j: int32, k: int32, value: Any):
-    """
-    Compute the maximum of ``value`` and ``array[index]`` and atomically update the array. Note that for vectors and matrices the operation is only atomic on a per-component basis.
-    """
-    ...
-
-
-@over
-def atomic_max(a: IndexedFabricArray[Any], i: int32, j: int32, k: int32, l: int32, value: Any):
     """
     Compute the maximum of ``value`` and ``array[index]`` and atomically update the array. Note that for vectors and matrices the operation is only atomic on a per-component basis.
     """
@@ -2139,19 +1862,19 @@ def sub(x: Transformation[Scalar], y: Transformation[Scalar]) -> Transformation[
 
 
 @over
-def bit_and(x: Int, y: Int) -> Int:
+def logical_and(x: Int, y: Int) -> Int:
     """ """
     ...
 
 
 @over
-def bit_or(x: Int, y: Int) -> Int:
+def logical_or(x: Int, y: Int) -> Int:
     """ """
     ...
 
 
 @over
-def bit_xor(x: Int, y: Int) -> Int:
+def logical_xor(x: Int, y: Int) -> Int:
     """ """
     ...
 
@@ -2332,12 +2055,6 @@ def neg(x: Quaternion[Scalar]) -> Quaternion[Scalar]:
 
 @over
 def neg(x: Matrix[Any, Any, Scalar]) -> Matrix[Any, Any, Scalar]:
-    """ """
-    ...
-
-
-@over
-def unot(b: bool) -> bool:
     """ """
     ...
 

--- a/warp/torch.py
+++ b/warp/torch.py
@@ -5,11 +5,9 @@
 # distribution of this software and related documentation without an express
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 
-import ctypes
-
-import numpy
-
 import warp
+import numpy
+import ctypes
 
 
 # return the warp device corresponding to a torch device
@@ -44,7 +42,7 @@ def dtype_from_torch(torch_dtype):
             torch.int16: warp.int16,
             torch.int8: warp.int8,
             torch.uint8: warp.uint8,
-            torch.bool: warp.bool,
+            torch.bool: warp.uint8,
             # currently unsupported by Warp
             # torch.bfloat16:
             # torch.complex64:
@@ -78,7 +76,7 @@ def dtype_is_compatible(torch_dtype, warp_dtype):
             torch.int16: {warp.int16, warp.uint16},
             torch.int8: {warp.int8, warp.uint8},
             torch.uint8: {warp.uint8, warp.int8},
-            torch.bool: {warp.bool, warp.uint8, warp.int8},
+            torch.bool: {warp.uint8, warp.int8},
             # currently unsupported by Warp
             # torch.bfloat16:
             # torch.complex64:
@@ -151,7 +149,7 @@ def from_torch(t, dtype=None, requires_grad=None, grad=None):
             import torch
 
             if isinstance(grad, torch.Tensor):
-                grad = from_torch(grad, dtype=dtype)
+                grad = from_torch(grad)
             else:
                 raise ValueError(f"Invalid gradient type: {type(grad)}")
     elif requires_grad:
@@ -159,9 +157,8 @@ def from_torch(t, dtype=None, requires_grad=None, grad=None):
         if t.grad is None:
             # allocate a zero-filled gradient tensor if it doesn't exist
             import torch
-
             t.grad = torch.zeros_like(t, requires_grad=False)
-        grad = from_torch(t.grad, dtype=dtype)
+        grad = from_torch(t.grad)
 
     a = warp.types.array(
         ptr=t.data_ptr(),

--- a/warp/types.py
+++ b/warp/types.py
@@ -5,14 +5,19 @@
 # distribution of this software and related documentation without an express
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 
-import builtins
 import ctypes
 import hashlib
 import struct
 import zlib
-from typing import Any, Callable, Generic, List, Tuple, TypeVar, Union
-
 import numpy as np
+
+from typing import Any
+from typing import Tuple
+from typing import TypeVar
+from typing import Generic
+from typing import List
+from typing import Callable
+from typing import Union
 
 import warp
 
@@ -53,7 +58,7 @@ def constant(x):
         _constant_hash.update(struct.pack("<q", x))
     elif isinstance(x, float):
         _constant_hash.update(struct.pack("<d", x))
-    elif isinstance(x, builtins.bool):
+    elif isinstance(x, bool):
         _constant_hash.update(struct.pack("?", x))
     elif isinstance(x, float16):
         # float16 is a special case
@@ -385,14 +390,6 @@ def matrix(shape, dtype):
 class void:
     def __init__(self):
         pass
-
-
-class bool:
-    _length_ = 1
-    _type_ = ctypes.c_bool
-
-    def __init__(self, x=False):
-        self.value = x
 
 
 class float16:
@@ -811,7 +808,6 @@ vector_types = [
 ]
 
 np_dtype_to_warp_type = {
-    np.dtype(np.bool_): bool,
     np.dtype(np.int8): int8,
     np.dtype(np.uint8): uint8,
     np.dtype(np.int16): int16,
@@ -828,7 +824,6 @@ np_dtype_to_warp_type = {
 }
 
 warp_type_to_np_dtype = {
-    bool: np.bool_,
     int8: np.int8,
     int16: np.int16,
     int32: np.int32,
@@ -874,8 +869,6 @@ LAUNCH_MAX_DIMS = 4
 # must match array.h
 ARRAY_TYPE_REGULAR = 0
 ARRAY_TYPE_INDEXED = 1
-ARRAY_TYPE_FABRIC = 2
-ARRAY_TYPE_FABRIC_INDEXED = 3
 
 
 # represents bounds for kernel launch (number of threads across multiple dimensions)
@@ -1022,9 +1015,7 @@ def type_to_warp(dtype):
 def type_typestr(dtype):
     from warp.codegen import Struct
 
-    if dtype == bool:
-        return "?"
-    elif dtype == float16:
+    if dtype == float16:
         return "<f2"
     elif dtype == float32:
         return "<f4"
@@ -1107,7 +1098,7 @@ def type_is_matrix(t):
 
 # returns true for all value types (int, float, bool, scalars, vectors, matrices)
 def type_is_value(x):
-    if (x == int) or (x == float) or (x == builtins.bool) or (x in scalar_types) or issubclass(x, ctypes.Array):
+    if (x == int) or (x == float) or (x == bool) or (x in scalar_types) or issubclass(x, ctypes.Array):
         return True
     else:
         return False
@@ -1135,15 +1126,13 @@ def types_equal(a, b, match_generic=False):
     # convert to canonical types
     if a == float:
         a = float32
-    elif a == int:
+    if a == int:
         a = int32
 
     if b == float:
         b = float32
-    elif b == int:
+    if b == int:
         b = int32
-
-    compatible_bool_types = [builtins.bool, bool]
 
     def are_equal(p1, p2):
         if match_generic:
@@ -1161,11 +1150,7 @@ def types_equal(a, b, match_generic=False):
                 return True
             if p1 == Float and p2 == Float:
                 return True
-
-        if p1 in compatible_bool_types and p2 in compatible_bool_types:
-            return True
-        else:
-            return p1 == p2
+        return p1 == p2
 
     if (
         hasattr(a, "_wp_generic_type_str_")
@@ -1173,7 +1158,9 @@ def types_equal(a, b, match_generic=False):
         and a._wp_generic_type_str_ == b._wp_generic_type_str_
     ):
         return all([are_equal(p1, p2) for p1, p2 in zip(a._wp_type_params_, b._wp_type_params_)])
-    if is_array(a) and type(a) == type(b):
+    if isinstance(a, array) and isinstance(b, array):
+        return True
+    if isinstance(a, indexedarray) and isinstance(b, indexedarray):
         return True
     else:
         return are_equal(a, b)
@@ -1330,9 +1317,7 @@ class array(Array):
             if isinstance(data, np.ndarray):
                 # construct from numpy structured array
                 if data.dtype != dtype.numpy_dtype():
-                    raise RuntimeError(
-                        f"Invalid source data type for array of structs, expected {dtype.numpy_dtype()}, got {data.dtype}"
-                    )
+                    raise RuntimeError(f"Invalid source data type for array of structs, expected {dtype.numpy_dtype()}, got {data.dtype}")
                 arr = data
             elif isinstance(data, (list, tuple)):
                 # construct from a sequence of structs
@@ -1344,13 +1329,9 @@ class array(Array):
                     # convert to numpy
                     arr = np.frombuffer(ctype_arr, dtype=dtype.ctype)
                 except Exception as e:
-                    raise RuntimeError(
-                        f"Error while trying to construct Warp array from a sequence of Warp structs: {e}"
-                    )
+                    raise RuntimeError(f"Error while trying to construct Warp array from a sequence of Warp structs: {e}")
             else:
-                raise RuntimeError(
-                    "Invalid data argument for array of structs, expected a sequence of structs or a NumPy structured array"
-                )
+                raise RuntimeError(f"Invalid data argument for array of structs, expected a sequence of structs or a NumPy structured array")
         else:
             # convert input data to the given dtype
             npdtype = warp_type_to_np_dtype.get(scalar_dtype)
@@ -1435,7 +1416,7 @@ class array(Array):
 
     def _init_from_ptr(self, ptr, dtype, shape, strides, capacity, device, owner, pinned):
         if dtype == Any:
-            raise RuntimeError("A concrete data type is required to create the array")
+            raise RuntimeError(f"A concrete data type is required to create the array")
 
         device = warp.get_device(device)
 
@@ -1469,7 +1450,7 @@ class array(Array):
 
     def _init_new(self, dtype, shape, strides, device, pinned):
         if dtype == Any:
-            raise RuntimeError("A concrete data type is required to create the array")
+            raise RuntimeError(f"A concrete data type is required to create the array")
 
         device = warp.get_device(device)
 
@@ -1768,11 +1749,29 @@ class array(Array):
         self.ctype = None
 
     @property
+    def grad(self):
+        return self._grad
+
+    @grad.setter
+    def grad(self, value):
+        # trigger re-creation of C-representation
+        self.ctype = None
+        if value is None:
+            self.grad_ptr = None
+            self._grad = None
+            return
+        if self._grad is None:
+            self.grad_ptr = value.ptr
+            self._grad = value
+        else:
+            self._grad.assign(value)
+
+    @property
     def requires_grad(self):
         return self._requires_grad
 
     @requires_grad.setter
-    def requires_grad(self, value: builtins.bool):
+    def requires_grad(self, value: bool):
         if value and self._grad is None:
             self._alloc_grad()
         elif not value:
@@ -1797,7 +1796,9 @@ class array(Array):
         # member attributes available during code-gen (e.g.: d = array.shape[0])
         # Note: we use a shared dict for all array instances
         if array._vars is None:
-            array._vars = {"shape": warp.codegen.Var("shape", shape_t)}
+            from warp.codegen import Var
+
+            array._vars = {"shape": Var("shape", shape_t)}
         return array._vars
 
     def zero_(self):
@@ -2110,7 +2111,7 @@ def from_ptr(ptr, length, dtype=None, shape=None, device=None):
         dtype=dtype,
         length=length,
         capacity=length * type_size_in_bytes(dtype),
-        ptr=0 if ptr == 0 else ctypes.cast(ptr, ctypes.POINTER(ctypes.c_size_t)).contents.value,
+        ptr=ctypes.cast(ptr, ctypes.POINTER(ctypes.c_size_t)).contents.value,
         shape=shape,
         device=device,
         owner=False,
@@ -2118,20 +2119,122 @@ def from_ptr(ptr, length, dtype=None, shape=None, device=None):
     )
 
 
-# A base class for non-contiguous arrays, providing the implementation of common methods like
-# contiguous(), to(), numpy(), list(), assign(), zero_(), and fill_().
-class noncontiguous_array_base(Generic[T]):
-    def __init__(self, array_type_id):
-        self.type_id = array_type_id
+class indexedarray(Generic[T]):
+    # member attributes available during code-gen (e.g.: d = arr.shape[0])
+    # (initialized when needed)
+    _vars = None
+
+    def __init__(self, data: array = None, indices: Union[array, List[array]] = None, dtype=None, ndim=None):
+        # canonicalize types
+        if dtype is not None:
+            if dtype == int:
+                dtype = int32
+            elif dtype == float:
+                dtype = float32
+
+        self.data = data
+        self.indices = [None] * ARRAY_MAX_DIMS
+
+        if data is not None:
+            if not isinstance(data, array):
+                raise ValueError("Indexed array data must be a Warp array")
+            if dtype is not None and dtype != data.dtype:
+                raise ValueError(f"Requested dtype ({dtype}) does not match dtype of data array ({data.dtype})")
+            if ndim is not None and ndim != data.ndim:
+                raise ValueError(
+                    f"Requested dimensionality ({ndim}) does not match dimensionality of data array ({data.ndim})"
+                )
+
+            self.dtype = data.dtype
+            self.ndim = data.ndim
+            self.device = data.device
+            self.pinned = data.pinned
+
+            # determine shape from original data shape and index counts
+            shape = list(data.shape)
+
+            if indices is not None:
+                # helper to check index array properties
+                def check_index_array(inds, data):
+                    if inds.ndim != 1:
+                        raise ValueError(f"Index array must be one-dimensional, got {inds.ndim}")
+                    if inds.dtype != int32:
+                        raise ValueError(f"Index array must use int32, got dtype {inds.dtype}")
+                    if inds.device != data.device:
+                        raise ValueError(
+                            f"Index array device ({inds.device} does not match data array device ({data.device}))"
+                        )
+
+                if isinstance(indices, (list, tuple)):
+                    if len(indices) > self.ndim:
+                        raise ValueError(
+                            f"Number of indices provided ({len(indices)}) exceeds number of dimensions ({self.ndim})"
+                        )
+
+                    for i in range(len(indices)):
+                        if isinstance(indices[i], array):
+                            check_index_array(indices[i], data)
+                            self.indices[i] = indices[i]
+                            shape[i] = len(indices[i])
+                        elif indices[i] is not None:
+                            raise TypeError(f"Invalid index array type: {type(indices[i])}")
+
+                elif isinstance(indices, array):
+                    # only a single index array was provided
+                    check_index_array(indices, data)
+                    self.indices[0] = indices
+                    shape[0] = len(indices)
+
+                else:
+                    raise ValueError("Indices must be a single Warp array or a list of Warp arrays")
+
+            self.shape = tuple(shape)
+
+        else:
+            # allow empty indexedarrays in type annotations
+            self.dtype = dtype
+            self.ndim = ndim or 1
+            self.device = None
+            self.pinned = False
+            self.shape = (0,) * self.ndim
+
+        # update size (num elements)
+        self.size = 1
+        for d in self.shape:
+            self.size *= d
+
         self.is_contiguous = False
 
-    # return a contiguous copy
+    def __len__(self):
+        return self.shape[0]
+
+    def __str__(self):
+        if self.device is None:
+            # type annotation
+            return f"indexedarray{self.dtype}"
+        else:
+            return str(self.numpy())
+
+    # construct a C-representation of the array for passing to kernels
+    def __ctype__(self):
+        return indexedarray_t(self.data, self.indices, self.shape)
+
+    @property
+    def vars(self):
+        # member attributes available during code-gen (e.g.: d = arr.shape[0])
+        # Note: we use a shared dict for all indexedarray instances
+        if indexedarray._vars is None:
+            from warp.codegen import Var
+
+            indexedarray._vars = {"shape": Var("shape", shape_t)}
+        return indexedarray._vars
+
     def contiguous(self):
         a = warp.empty_like(self)
         warp.copy(a, self)
         return a
 
-    # copy data from one device to another, nop if already on device
+    # convert data from one device to another, nop if already on device
     def to(self, device):
         device = warp.get_device(device)
         if self.device == device:
@@ -2150,13 +2253,6 @@ class noncontiguous_array_base(Generic[T]):
         # use the CUDA default stream for synchronous behaviour with other streams
         with warp.ScopedStream(self.device.null_stream):
             return self.contiguous().list()
-
-    # equivalent to wrapping src data in an array and copying to self
-    def assign(self, src):
-        if is_array(src):
-            warp.copy(self, src)
-        else:
-            warp.copy(self, array(data=src, dtype=self.dtype, copy=False, device="cpu"))
 
     def zero_(self):
         self.fill_(0)
@@ -2199,118 +2295,17 @@ class noncontiguous_array_base(Generic[T]):
 
         if self.device.is_cuda:
             warp.context.runtime.core.array_fill_device(
-                self.device.context, ctype_ptr, self.type_id, cvalue_ptr, cvalue_size
+                self.device.context, ctype_ptr, ARRAY_TYPE_INDEXED, cvalue_ptr, cvalue_size
             )
         else:
-            warp.context.runtime.core.array_fill_host(ctype_ptr, self.type_id, cvalue_ptr, cvalue_size)
+            warp.context.runtime.core.array_fill_host(ctype_ptr, ARRAY_TYPE_INDEXED, cvalue_ptr, cvalue_size)
 
-
-# helper to check index array properties
-def check_index_array(indices, expected_device):
-    if not isinstance(indices, array):
-        raise ValueError(f"Indices must be a Warp array, got {type(indices)}")
-    if indices.ndim != 1:
-        raise ValueError(f"Index array must be one-dimensional, got {indices.ndim}")
-    if indices.dtype != int32:
-        raise ValueError(f"Index array must use int32, got dtype {indices.dtype}")
-    if indices.device != expected_device:
-        raise ValueError(f"Index array device ({indices.device} does not match data array device ({expected_device}))")
-
-
-class indexedarray(noncontiguous_array_base[T]):
-    # member attributes available during code-gen (e.g.: d = arr.shape[0])
-    # (initialized when needed)
-    _vars = None
-
-    def __init__(self, data: array = None, indices: Union[array, List[array]] = None, dtype=None, ndim=None):
-        super().__init__(ARRAY_TYPE_INDEXED)
-
-        # canonicalize types
-        if dtype is not None:
-            if dtype == int:
-                dtype = int32
-            elif dtype == float:
-                dtype = float32
-
-        self.data = data
-        self.indices = [None] * ARRAY_MAX_DIMS
-
-        if data is not None:
-            if not isinstance(data, array):
-                raise ValueError("Indexed array data must be a Warp array")
-            if dtype is not None and dtype != data.dtype:
-                raise ValueError(f"Requested dtype ({dtype}) does not match dtype of data array ({data.dtype})")
-            if ndim is not None and ndim != data.ndim:
-                raise ValueError(
-                    f"Requested dimensionality ({ndim}) does not match dimensionality of data array ({data.ndim})"
-                )
-
-            self.dtype = data.dtype
-            self.ndim = data.ndim
-            self.device = data.device
-            self.pinned = data.pinned
-
-            # determine shape from original data shape and index counts
-            shape = list(data.shape)
-
-            if indices is not None:
-                if isinstance(indices, (list, tuple)):
-                    if len(indices) > self.ndim:
-                        raise ValueError(
-                            f"Number of indices provided ({len(indices)}) exceeds number of dimensions ({self.ndim})"
-                        )
-
-                    for i in range(len(indices)):
-                        if indices[i] is not None:
-                            check_index_array(indices[i], data.device)
-                            self.indices[i] = indices[i]
-                            shape[i] = len(indices[i])
-
-                elif isinstance(indices, array):
-                    # only a single index array was provided
-                    check_index_array(indices, data.device)
-                    self.indices[0] = indices
-                    shape[0] = len(indices)
-
-                else:
-                    raise ValueError("Indices must be a single Warp array or a list of Warp arrays")
-
-            self.shape = tuple(shape)
-
+    # equivalent to wrapping src data in an array and copying to self
+    def assign(self, src):
+        if is_array(src):
+            warp.copy(self, src)
         else:
-            # allow empty indexedarrays in type annotations
-            self.dtype = dtype
-            self.ndim = ndim or 1
-            self.device = None
-            self.pinned = False
-            self.shape = (0,) * self.ndim
-
-        # update size (num elements)
-        self.size = 1
-        for d in self.shape:
-            self.size *= d
-
-    def __len__(self):
-        return self.shape[0]
-
-    def __str__(self):
-        if self.device is None:
-            # type annotation
-            return f"indexedarray{self.dtype}"
-        else:
-            return str(self.numpy())
-
-    # construct a C-representation of the array for passing to kernels
-    def __ctype__(self):
-        return indexedarray_t(self.data, self.indices, self.shape)
-
-    @property
-    def vars(self):
-        # member attributes available during code-gen (e.g.: d = arr.shape[0])
-        # Note: we use a shared dict for all indexedarray instances
-        if indexedarray._vars is None:
-            indexedarray._vars = {"shape": warp.codegen.Var("shape", shape_t)}
-        return indexedarray._vars
+            warp.copy(self, array(data=src, dtype=self.dtype, copy=False, device="cpu"))
 
 
 # aliases for indexedarrays with small dimensions
@@ -2337,22 +2332,16 @@ def indexedarray4d(*args, **kwargs):
     return indexedarray(*args, **kwargs)
 
 
-from warp.fabric import fabricarray, indexedfabricarray  # noqa: E402
-
-array_types = (array, indexedarray, fabricarray, indexedfabricarray)
+array_types = (array, indexedarray)
 
 
 def array_type_id(a):
-    if isinstance(a, array):
-        return ARRAY_TYPE_REGULAR
-    elif isinstance(a, indexedarray):
-        return ARRAY_TYPE_INDEXED
-    elif isinstance(a, fabricarray):
-        return ARRAY_TYPE_FABRIC
-    elif isinstance(a, indexedfabricarray):
-        return ARRAY_TYPE_FABRIC_INDEXED
+    if isinstance(a, warp.array):
+        return warp.types.ARRAY_TYPE_REGULAR
+    elif isinstance(a, warp.indexedarray):
+        return warp.types.ARRAY_TYPE_INDEXED
     else:
-        raise ValueError("Invalid array type")
+        raise ValueError(f"Invalid array")
 
 
 class Bvh:
@@ -2410,11 +2399,11 @@ class Bvh:
                 with self.device.context_guard:
                     runtime.core.bvh_destroy_device(self.id)
 
-        except Exception:
+        except:
             pass
 
     def refit(self):
-        """Refit the BVH. This should be called after users modify the `lowers` and `uppers` arrays."""
+        """Refit the Bvh. This should be called after users modify the `lowers` and `uppers` arrays."""
 
         from warp.context import runtime
 
@@ -2500,7 +2489,7 @@ class Mesh:
                 # use CUDA context guard to avoid side effects during garbage collection
                 with self.device.context_guard:
                     runtime.core.mesh_destroy_device(self.id)
-        except Exception:
+        except:
             pass
 
     def refit(self):
@@ -2567,7 +2556,7 @@ class Volume:
                 with self.device.context_guard:
                     runtime.core.volume_destroy_device(self.id)
 
-        except Exception:
+        except:
             pass
 
     def array(self):
@@ -2602,12 +2591,6 @@ class Volume:
 
     @classmethod
     def load_from_nvdb(cls, file_or_buffer, device=None):
-        """Creates a Volume object from a NanoVDB file or in-memory buffer.
-
-        Returns:
-
-            A ``warp.Volume`` object.
-        """
         try:
             data = file_or_buffer.read()
         except AttributeError:
@@ -2635,86 +2618,6 @@ class Volume:
 
         data_array = array(np.frombuffer(grid_data, dtype=np.byte), device=device)
         return cls(data_array)
-
-    @classmethod
-    def load_from_numpy(cls, ndarray: np.array, min_world=(0.0, 0.0, 0.0), voxel_size=1.0, bg_value=0.0, device=None):
-        """Creates a Volume object from a dense 3D NumPy array.
-
-        Args:
-            min_world: The 3D coordinate of the lower corner of the volume
-            voxel_size: The size of each voxel in spatial coordinates
-            bg_value: Background value
-            device: The device to create the volume on, e.g.: "cpu", or "cuda:0"
-
-        Returns:
-
-            A ``warp.Volume`` object.
-        """
-
-        import math
-
-        target_shape = (
-            math.ceil(ndarray.shape[0] / 8) * 8,
-            math.ceil(ndarray.shape[1] / 8) * 8,
-            math.ceil(ndarray.shape[2] / 8) * 8,
-        )
-        if hasattr(bg_value, "__len__"):
-            # vec3, assuming the numpy array is 4D
-            padded_array = np.array((target_shape[0], target_shape[1], target_shape[2], 3), dtype=np.single)
-            padded_array[:, :, :, :] = np.array(bg_value)
-            padded_array[0 : ndarray.shape[0], 0 : ndarray.shape[1], 0 : ndarray.shape[2], :] = ndarray
-        else:
-            padded_amount = (
-                math.ceil(ndarray.shape[0] / 8) * 8 - ndarray.shape[0],
-                math.ceil(ndarray.shape[1] / 8) * 8 - ndarray.shape[1],
-                math.ceil(ndarray.shape[2] / 8) * 8 - ndarray.shape[2],
-            )
-            padded_array = np.pad(
-                ndarray,
-                ((0, padded_amount[0]), (0, padded_amount[1]), (0, padded_amount[2])),
-                mode="constant",
-                constant_values=bg_value,
-            )
-
-        shape = padded_array.shape
-        volume = warp.Volume.allocate(
-            min_world,
-            [
-                min_world[0] + (shape[0] - 1) * voxel_size,
-                min_world[1] + (shape[1] - 1) * voxel_size,
-                min_world[2] + (shape[2] - 1) * voxel_size,
-            ],
-            voxel_size,
-            bg_value=bg_value,
-            points_in_world_space=True,
-            translation=min_world,
-            device=device,
-        )
-
-        # Populate volume
-        if hasattr(bg_value, "__len__"):
-            warp.launch(
-                warp.utils.copy_dense_volume_to_nano_vdb_v,
-                dim=(shape[0], shape[1], shape[2]),
-                inputs=[volume.id, warp.array(padded_array, dtype=warp.vec3, device=device)],
-                device=device,
-            )
-        elif type(bg_value) == int:
-            warp.launch(
-                warp.utils.copy_dense_volume_to_nano_vdb_i,
-                dim=shape,
-                inputs=[volume.id, warp.array(padded_array, dtype=warp.int32, device=device)],
-                device=device,
-            )
-        else:
-            warp.launch(
-                warp.utils.copy_dense_volume_to_nano_vdb_f,
-                dim=shape,
-                inputs=[volume.id, warp.array(padded_array, dtype=warp.float32, device=device)],
-                device=device,
-            )
-
-        return volume
 
     @classmethod
     def allocate(
@@ -2860,7 +2763,7 @@ def matmul(
     d: array2d,
     alpha: float = 1.0,
     beta: float = 0.0,
-    allow_tf32x3_arith: builtins.bool = False,
+    allow_tf32x3_arith: bool = False,
     device=None,
 ):
     """Computes a generic matrix-matrix multiplication (GEMM) of the form: `d = alpha * (a @ b) + beta * c`.
@@ -2942,7 +2845,7 @@ def adj_matmul(
     adj_d: array2d,
     alpha: float = 1.0,
     beta: float = 0.0,
-    allow_tf32x3_arith: builtins.bool = False,
+    allow_tf32x3_arith: bool = False,
     device=None,
 ):
     """Computes the adjoint of a generic matrix-matrix multiplication (GEMM) of the form: `d = alpha * (a @ b) + beta * c`.
@@ -3091,7 +2994,7 @@ def batched_matmul(
     d: array3d,
     alpha: float = 1.0,
     beta: float = 0.0,
-    allow_tf32x3_arith: builtins.bool = False,
+    allow_tf32x3_arith: bool = False,
     device=None,
 ):
     """Computes a batched generic matrix-matrix multiplication (GEMM) of the form: `d = alpha * (a @ b) + beta * c`.
@@ -3174,7 +3077,7 @@ def adj_batched_matmul(
     adj_d: array3d,
     alpha: float = 1.0,
     beta: float = 0.0,
-    allow_tf32x3_arith: builtins.bool = False,
+    allow_tf32x3_arith: bool = False,
     device=None,
 ):
     """Computes a batched generic matrix-matrix multiplication (GEMM) of the form: `d = alpha * (a @ b) + beta * c`.
@@ -3336,6 +3239,9 @@ class HashGrid:
             self.id = runtime.core.hash_grid_create_host(dim_x, dim_y, dim_z)
         else:
             self.id = runtime.core.hash_grid_create_device(self.device.context, dim_x, dim_y, dim_z)
+        
+        # indicates whether the grid data has been reserved for use by a kernel
+        self.reserved = False
 
         # indicates whether the grid data has been reserved for use by a kernel
         self.reserved = False
@@ -3381,7 +3287,7 @@ class HashGrid:
                 with self.device.context_guard:
                     runtime.core.hash_grid_destroy_device(self.id)
 
-        except Exception:
+        except:
             pass
 
 
@@ -3455,7 +3361,7 @@ class MarchingCubes:
 
         if error:
             raise RuntimeError(
-                "Buffers may not be large enough, marching cubes required at least {num_verts} vertices, and {num_tris} triangles."
+                "Error occured buffers may not be large enough, marching cubes required at least {num_verts} vertices, and {num_tris} triangles."
             )
 
         # resize the geometry arrays
@@ -3544,7 +3450,7 @@ def infer_argument_types(args, template_types, arg_names=None):
     """Resolve argument types with the given list of template types."""
 
     if len(args) != len(template_types):
-        raise RuntimeError("Number of arguments must match number of template types.")
+        raise RuntimeError(f"Number of arguments must match number of template types.")
 
     arg_types = []
 
@@ -3586,7 +3492,6 @@ def infer_argument_types(args, template_types, arg_names=None):
 simple_type_codes = {
     int: "i4",
     float: "f4",
-    builtins.bool: "b",
     bool: "b",
     str: "str",  # accepted by print()
     int8: "i1",
@@ -3621,14 +3526,14 @@ def get_type_code(arg_type):
             # check for "special" vector/matrix subtypes
             if hasattr(arg_type, "_wp_generic_type_str_"):
                 type_str = arg_type._wp_generic_type_str_
-                if type_str == "quat_t":
+                if type_str == "quaternion":
                     return f"q{dtype_code}"
                 elif type_str == "transform_t":
                     return f"t{dtype_code}"
-                # elif type_str == "spatial_vector_t":
-                #     return f"sv{dtype_code}"
-                # elif type_str == "spatial_matrix_t":
-                #     return f"sm{dtype_code}"
+                elif type_str == "spatial_vector_t":
+                    return f"sv{dtype_code}"
+                elif type_str == "spatial_matrix_t":
+                    return f"sm{dtype_code}"
             # generic vector/matrix
             ndim = len(arg_type._shape_)
             if ndim == 1:
@@ -3651,10 +3556,6 @@ def get_type_code(arg_type):
         return f"a{arg_type.ndim}{get_type_code(arg_type.dtype)}"
     elif isinstance(arg_type, indexedarray):
         return f"ia{arg_type.ndim}{get_type_code(arg_type.dtype)}"
-    elif isinstance(arg_type, fabricarray):
-        return f"fa{arg_type.ndim}{get_type_code(arg_type.dtype)}"
-    elif isinstance(arg_type, indexedfabricarray):
-        return f"ifa{arg_type.ndim}{get_type_code(arg_type.dtype)}"
     elif isinstance(arg_type, warp.codegen.Struct):
         return warp.codegen.make_full_qualified_name(arg_type.cls)
     elif arg_type == Scalar:

--- a/warp/utils.py
+++ b/warp/utils.py
@@ -5,30 +5,15 @@
 # distribution of this software and related documentation without an express
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 
-import cProfile
+import os
 import math
-import sys
 import timeit
-import warnings
-from typing import Any, Tuple, Union
-
+import cProfile
 import numpy as np
+from typing import Union, Tuple, Any
 
 import warp as wp
 import warp.types
-
-
-def warp_showwarning(message, category, filename, lineno, file=None, line=None):
-    """Version of warnings.showwarning that always prints to sys.stdout."""
-    msg = warnings.WarningMessage(message, category, filename, lineno, sys.stdout, line)
-    warnings._showwarnmsg_impl(msg)
-
-
-def warn(message, category=None, stacklevel=1):
-    with warnings.catch_warnings():
-        warnings.simplefilter("default")  # Change the filter in this process
-        warnings.showwarning = warp_showwarning
-        warnings.warn(message, category, stacklevel + 1)  # Increment stacklevel by 1 since we are in a wrapper
 
 
 def length(a):
@@ -270,7 +255,6 @@ def transform_inertia(m, I, p, q):
 
     # Steiner's theorem
     return R @ I @ R.T + m * (np.dot(p, p) * np.eye(3) - np.outer(p, p))
-
 
 # spatial operators
 
@@ -668,7 +652,6 @@ _copy_kernel_cache = dict()
 def array_cast(in_array, out_array, count=None):
     def make_copy_kernel(dest_dtype, src_dtype):
         import re
-
         import warp.context
 
         def copy_kernel(
@@ -754,25 +737,6 @@ def array_cast(in_array, out_array, count=None):
 # exit(0)
 
 
-# helper kernels for initializing NVDB volumes from a dense array
-@wp.kernel
-def copy_dense_volume_to_nano_vdb_v(volume: wp.uint64, values: wp.array(dtype=wp.vec3, ndim=3)):
-    i, j, k = wp.tid()
-    wp.volume_store_v(volume, i, j, k, values[i, j, k])
-
-
-@wp.kernel
-def copy_dense_volume_to_nano_vdb_f(volume: wp.uint64, values: wp.array(dtype=wp.float32, ndim=3)):
-    i, j, k = wp.tid()
-    wp.volume_store_f(volume, i, j, k, values[i, j, k])
-
-
-@wp.kernel
-def copy_dense_volume_to_nano_vdb_i(volume: wp.uint64, values: wp.array(dtype=wp.int32, ndim=3)):
-    i, j, k = wp.tid()
-    wp.volume_store_i(volume, i, j, k, values[i, j, k])
-
-
 # represent an edge between v0, v1 with connected faces f0, f1, and opposite vertex o0, and o1
 # winding is such that first tri can be reconstructed as {v0, v1, o0}, and second tri as { v1, v0, o1 }
 class MeshEdge:
@@ -856,7 +820,6 @@ def mem_report():
         print("Type: %s Total Tensors: %d \tUsed Memory Space: %.2f MBytes" % (mem_type, total_numel, total_mem))
 
     import gc
-
     import torch
 
     gc.collect()


### PR DESCRIPTION
- Changes largely taken from @krishpop 's dmanip-suite branch
- The scripts currently work only when pair-warp is cloned inside of this repo and called as `python -m pair-warp.scripts.<script>` from the root directory of this repo. There's surely a cleaner way to do this.
- pair-warp/scripts/train.py does not work, config formatting needs to be updated @krishpop 